### PR TITLE
Fix bug when moving between rooms via link

### DIFF
--- a/src/networking.ts
+++ b/src/networking.ts
@@ -64,7 +64,7 @@ export async function moveToRoom(roomId: string) {
   if (result.error) {
     myDispatch(ErrorAction(result.error));
   } else {
-    myDispatch(UpdatedRoomAction(result));
+    myDispatch(UpdatedRoomAction(convertServerRoom(result)));
   }
 }
 


### PR DESCRIPTION
When you moved via clicking a link, the object set into the State was
the server-side representation. Converts the object to client-side
representation before saving it.

Before:

![Screenshot from 2020-08-01 12-36-26](https://user-images.githubusercontent.com/1434086/89109665-17086e00-d3f8-11ea-9341-222daff501ca.png)

After:

![Screenshot from 2020-08-01 12-37-12](https://user-images.githubusercontent.com/1434086/89109672-1d96e580-d3f8-11ea-8ff7-dd0fc0c921a2.png)
