### PR TITLE
Issue 43, Left click also opens name menu

### DIFF
--- a/src/components/NameView.tsx
+++ b/src/components/NameView.tsx
@@ -50,9 +50,13 @@ export default (props: { userId: string; id?: string }) => {
     ""
   );
 
+
+  //#issue 43: Left click for dropdowns in addition to rightclick. Apparently disabling "holdToDisplay" can make this happen,
+  //not sure what the side effects are though.
+  //https://github.com/vkbansal/react-contextmenu/issues/50#issuecomment-335855193
   return (
     <span className="name">
-      <ContextMenuTrigger id={props.id} renderTag="span">
+      <ContextMenuTrigger id={props.id} renderTag="span" holdToDisplay={0}>
         <strong>
           {username ? username : "unknown"}
           {isMod ? "👑" : ""}

--- a/src/components/RoomView.tsx
+++ b/src/components/RoomView.tsx
@@ -76,6 +76,7 @@ export default (props: Props) => {
 const PresenceView = (props: { users?: string[]; userId?: string }) => {
   let { users, userId } = props;
 
+  //Shep: Issue 43, reminder to myself that this is the code making sure users don't appear in their own client lists.
   if (users && userId) {
     users = users.filter((u) => u !== userId);
   }


### PR DESCRIPTION
Found this solution, and it seems like you used it as well for the clickable name at the top of the screen.