### PR TITLE
Fix bug causing the profile to never update

### DIFF
--- a/server/updateProfile/index.ts
+++ b/server/updateProfile/index.ts
@@ -28,6 +28,8 @@ const httpTrigger: AzureFunction = async function (
     data.twitterHandle = twitterHandle;
   }
 
+  await updateUserProfile(userId, data)
+
   // TODO: We'll likely eventually have some validation here
   context.res = {
     status: 200,


### PR DESCRIPTION
New users could not register their data and old users could not update their profile. Fixed bug by saving when update function called.

**Before:**

After submitting new data, it clears the form and shows `isRegistered` as empty:

![Screenshot from 2020-08-05 14-08-52](https://user-images.githubusercontent.com/1434086/89465226-9b276200-d726-11ea-9232-363f6493a212.png)

**After - Registration**

When submitting it updates and lets you pass through:

![workingupdate](https://user-images.githubusercontent.com/1434086/89465235-9cf12580-d726-11ea-8a1d-30a8fde43915.png)

**After - Updating Profile**

Showing previous & updated values before hitting Submit:

![beforenewsubmission](https://user-images.githubusercontent.com/1434086/89465234-9c588f00-d726-11ea-86ae-3271f043ab9d.png)

Showing values were successfully saved when returning to Profile screen:

![afternewsubmission](https://user-images.githubusercontent.com/1434086/89465229-9bbff880-d726-11ea-8e3f-d16bceceddb7.png)
