### PR TITLE
Issue 68: Add /me and /emote commands

### DIFF
--- a/server/sendChatMessage/index.ts
+++ b/server/sendChatMessage/index.ts
@@ -43,6 +43,18 @@ const httpTrigger: AzureFunction = async function (
       return await shout(user, shoutMatch[2], context)
     }
 
+    const emoteMatch = /^\/(me|emote) (.+)/.exec(message)
+    if (emoteMatch) {
+      context.bindings.signalRMessages = [
+        {
+          groupName: user.roomId,
+          target: 'emote',
+          arguments: [user.id, emoteMatch[2]]
+        }
+      ]
+      return
+    }
+
     const modMatch = /^\/(mod) (.+)/.exec(message)
     if (modMatch) {
       // Send to the mod-only group

--- a/server/sendChatMessage/index.ts
+++ b/server/sendChatMessage/index.ts
@@ -59,7 +59,7 @@ const httpTrigger: AzureFunction = async function (
     const lookMatch = /^\/(look) (.+)/.exec(message)
     if (lookMatch) {
       const lookUserId = await getUserIdForUsername(lookMatch[2])
-      if (!lookMatch) {
+      if (!lookUserId) {
         context.res = {
           status: 400,
           body: { error: `Could not find the user ${lookMatch[2]}` }

--- a/src/Actions.ts
+++ b/src/Actions.ts
@@ -15,6 +15,7 @@ export type Action =
   | ModMessageAction
   | WhisperAction
   | ShoutAction
+  | EmoteAction
   | PlayerEnteredAction
   | PlayerLeftAction
   | UserMapAction
@@ -48,6 +49,7 @@ export enum ActionType {
   ModMessage = "MOD_MESSAGE",
   Whisper = "WHISPER",
   Shout = "SHOUT",
+  Emote = "EMOTE",
   PlayerEntered = "PLAYER_ENTERED",
   PlayerLeft = "PLAYER_LEFT",
   Error = "ERROR",
@@ -221,6 +223,21 @@ interface ShoutAction {
     name: string;
     message: string;
   };
+}
+
+interface EmoteAction {
+  type: ActionType.Emote;
+  value: {
+    name: string;
+    message: string;
+  }
+}
+
+export const EmoteAction = (name: string, message: string): EmoteAction => {
+  return {
+    type: ActionType.Emote,
+    value: { name, message }
+  }
 }
 
 interface PlayerEnteredAction {

--- a/src/components/MessageView.tsx
+++ b/src/components/MessageView.tsx
@@ -139,7 +139,7 @@ const ShoutView = (props: ShoutMessage & { id: string }) => {
 const EmoteView = (props: EmoteMessage & { id: string }) => {
   return (
     <div className="message">
-      <NameView userId={props.userId} id={props.id} /> <em>{props.message}</em>
+      <em><NameView userId={props.userId} id={props.id} /> {props.message}</em>
     </div>
   )
 }

--- a/src/components/MessageView.tsx
+++ b/src/components/MessageView.tsx
@@ -11,6 +11,7 @@ import {
   WhisperMessage,
   ErrorMessage,
   ShoutMessage,
+  EmoteMessage,
   ModMessage
 } from '../message'
 import NameView from './NameView'
@@ -27,6 +28,7 @@ export default function MessageView (props: { message: Message; id: string }) {
     [MessageType.Chat]: ChatMessageView,
     [MessageType.Whisper]: WhisperView,
     [MessageType.Shout]: ShoutView,
+    [MessageType.Emote]: EmoteView,
     [MessageType.Error]: ErrorView,
     [MessageType.Mod]: ModMessageView
   }
@@ -130,6 +132,14 @@ const ShoutView = (props: ShoutMessage & { id: string }) => {
   return (
     <div className="message">
       <NameView userId={props.userId} id={props.id} /> shouts: {props.message}
+    </div>
+  )
+}
+
+const EmoteView = (props: EmoteMessage & { id: string }) => {
+  return (
+    <div className="message">
+      <NameView userId={props.userId} id={props.id} /> <em>{props.message}</em>
     </div>
   )
 }

--- a/src/message.ts
+++ b/src/message.ts
@@ -7,6 +7,7 @@ export type Message =
   | ChatMessage
   | WhisperMessage
   | ShoutMessage
+  | EmoteMessage
   | ModMessage
   | ErrorMessage;
 
@@ -19,6 +20,7 @@ export enum MessageType {
   Chat = "CHAT",
   Whisper = "WHISPER",
   Shout = "SHOUT",
+  Emote = "EMOTE",
   Mod = "MOD",
   Error = "ERROR",
 }
@@ -130,6 +132,19 @@ export const createShoutMessage = (
 ): ShoutMessage => {
   return { type: MessageType.Shout, userId, message };
 };
+
+export interface EmoteMessage {
+  type: MessageType.Emote;
+  userId: string;
+  message: string;
+}
+
+export const createEmoteMessage = (
+  userId: string,
+  message: string
+): EmoteMessage => {
+  return { type: MessageType.Emote, userId, message}
+}
 
 export interface ErrorMessage {
   type: MessageType.Error;

--- a/src/networking.ts
+++ b/src/networking.ts
@@ -13,6 +13,7 @@ import {
   WhisperAction,
   PlayerLeftAction,
   ShoutAction,
+  EmoteAction,
   ShowProfileActionForFetchedUser,
   UserMapAction,
   ModMessageAction,
@@ -214,6 +215,10 @@ async function connectSignalR(userId: string, dispatch: Dispatch<Action>) {
     // We don't gate on your own userId here.
     // Because shouting can fail at the server level, we don't show it preemptively.
     dispatch(ShoutAction(name, message));
+  });
+
+  connection.on("emote", (name, message) => {
+    dispatch(EmoteAction(name, message))
   });
 
   connection.on("webrtcSignalData", (peerId, data) => {

--- a/src/reducer.ts
+++ b/src/reducer.ts
@@ -9,6 +9,7 @@ import {
   createWhisperMessage,
   createErrorMessage,
   createShoutMessage,
+  createEmoteMessage,
   createModMessage,
   createMovedRoomMessage,
 } from "./message";
@@ -174,6 +175,12 @@ export default (oldState: State, action: Action): State => {
     state.messages.push(
       createShoutMessage(action.value.name, action.value.message)
     );
+  }
+
+  if (action.type == ActionType.Emote) {
+    state.messages.push(
+      createEmoteMessage(action.value.name, action.value.message)
+    )
   }
 
   if (action.type === ActionType.UserMap) {


### PR DESCRIPTION
Adds /me and /emote commands. They resolve identically:

![emote](https://user-images.githubusercontent.com/1434086/89721452-76cfbd80-d992-11ea-80d7-07b6578619b6.png)

Also includes a fix for an error check in the /look command, which I didn't bother to try to reproduce.