### PR TITLE
Save userMap to localstorage

### DIFF
--- a/src/Actions.ts
+++ b/src/Actions.ts
@@ -568,11 +568,12 @@ export const BanToggleAction = (userId: string): BanToggleAction => {
 
 interface LoadMessageArchiveAction {
   type: ActionType.LoadMessageArchive;
-  value: Message[];
+  messages: Message[];
+  userMap: { [userId: string]: MinimalUser };
 }
 
-export const LoadMessageArchiveAction = (messages: Message[]): LoadMessageArchiveAction => {
-  return { type: ActionType.LoadMessageArchive, value: messages }
+export const LoadMessageArchiveAction = (messages: Message[], userMap: { [userId: string]: MinimalUser }): LoadMessageArchiveAction => {
+  return { type: ActionType.LoadMessageArchive, messages: messages, userMap: userMap }
 }
 
 interface NoteAddAction {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,23 +40,25 @@ const App = () => {
         checkIsRegistered().then((registered) => {
           dispatch(AuthenticateAction(userId, name))
           if (registered) {
-            let loadMessages = false
+            let localLocalData = false
             const rawTimestamp = localStorage.getItem('messageTimestamp')
             const rawMessageData = localStorage.getItem('messages')
+            const rawUserMapData = localStorage.getItem('userMap')
             if (rawTimestamp) {
               try {
                 const timestamp = new Date(rawTimestamp)
                 // A janky way to say "Is it older than an hour"
-                loadMessages = rawMessageData && (new Date()).getTime() - timestamp.getTime() < 1000 * 60 * 60
+                localLocalData = rawMessageData && (new Date()).getTime() - timestamp.getTime() < 1000 * 60 * 60
               } catch {
                 console.log('Did not find a valid timestamp for message cache')
               }
             }
 
-            if (loadMessages) {
+            if (localLocalData) {
               try {
                 const messages = JSON.parse(rawMessageData)
-                dispatch(LoadMessageArchiveAction(messages))
+                const userMap = JSON.parse(rawUserMapData)
+                dispatch(LoadMessageArchiveAction(messages, userMap))
               } catch {
                 console.log('Could not parse message JSON', rawMessageData)
               }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -57,10 +57,10 @@ const App = () => {
             if (localLocalData) {
               try {
                 const messages = JSON.parse(rawMessageData)
-                const userMap = JSON.parse(rawUserMapData)
+                const userMap = !(rawUserMapData === undefined) ? JSON.parse(rawUserMapData) : null
                 dispatch(LoadMessageArchiveAction(messages, userMap))
-              } catch {
-                console.log('Could not parse message JSON', rawMessageData)
+              } catch (e) {
+                console.log('Could not parse message JSON', e)
               }
             }
 

--- a/src/reducer.ts
+++ b/src/reducer.ts
@@ -311,7 +311,9 @@ export default (oldState: State, action: Action): State => {
 
   if (action.type === ActionType.LoadMessageArchive) {
     state.messages = action.messages
-    state.userMap = action.userMap
+    if (action.userMap) {
+      state.userMap = action.userMap
+    }
   }
 
   // Notes

--- a/src/reducer.ts
+++ b/src/reducer.ts
@@ -78,17 +78,6 @@ export default (oldState: State, action: Action): State => {
   const state: State = JSON.parse(JSON.stringify(oldState))
   state.prepopulatedInput = undefined
 
-  // Only join local users into the userMap if we don't already have them - server users are fresher & may contain updates
-  const localUserMapString = localStorage.getItem('userMap')
-  if (localUserMapString) {
-    const localUserMap: { [userId: string]: MinimalUser } = JSON.parse(localUserMapString)
-    for (const key in localUserMap) {
-      if (!state.userMap[key]) {
-        state.userMap[key] = localUserMap[key]
-      }
-    }
-  }
-
   if (action.type === ActionType.ReceivedMyProfile) {
     state.profileData = action.value
   }
@@ -137,6 +126,7 @@ export default (oldState: State, action: Action): State => {
       addMessage(state, createConnectedMessage(user.id))
     }
     state.userMap[user.id] = user
+    localStorage.setItem('userMap', JSON.stringify(state.userMap))
   }
 
   if (action.type === ActionType.PlayerDisconnected) {
@@ -202,6 +192,7 @@ export default (oldState: State, action: Action): State => {
 
   if (action.type === ActionType.UserMap) {
     state.userMap = { ...state.userMap, ...action.value }
+    localStorage.setItem('userMap', JSON.stringify(state.userMap))
   }
 
   if (action.type === ActionType.Error) {
@@ -319,7 +310,8 @@ export default (oldState: State, action: Action): State => {
   }
 
   if (action.type === ActionType.LoadMessageArchive) {
-    state.messages = action.value
+    state.messages = action.messages
+    state.userMap = action.userMap
   }
 
   // Notes
@@ -359,10 +351,6 @@ export default (oldState: State, action: Action): State => {
       room.notes = action.value.notes
     }
   }
-
-  // The userMap is always saved so if somebody writes new functionality that edits the userMap, they don't have to remember
-  // to save it.
-  localStorage.setItem('userMap', JSON.stringify(state.userMap))
 
   return state
 }

--- a/src/reducer.ts
+++ b/src/reducer.ts
@@ -78,6 +78,17 @@ export default (oldState: State, action: Action): State => {
   const state: State = JSON.parse(JSON.stringify(oldState))
   state.prepopulatedInput = undefined
 
+  // Only join local users into the userMap if we don't already have them - server users are fresher & may contain updates
+  const localUserMapString = localStorage.getItem('userMap')
+  if (localUserMapString) {
+    const localUserMap: { [userId: string]: MinimalUser } = JSON.parse(localUserMapString)
+    for (const key in localUserMap) {
+      if (!state.userMap[key]) {
+        state.userMap[key] = localUserMap[key]
+      }
+    }
+  }
+
   if (action.type === ActionType.ReceivedMyProfile) {
     state.profileData = action.value
   }
@@ -348,6 +359,10 @@ export default (oldState: State, action: Action): State => {
       room.notes = action.value.notes
     }
   }
+
+  // The userMap is always saved so if somebody writes new functionality that edits the userMap, they don't have to remember
+  // to save it.
+  localStorage.setItem('userMap', JSON.stringify(state.userMap))
 
   return state
 }


### PR DESCRIPTION
It saves on every state update, which I don't think is a huge deal, since I wouldn't expect more than...several hundred items, at most? However, we could also do a deep copy of the users map and compare it before saving for changes, if localstorage perf is a concern but I think it can totally take it.

![beforerefresh](https://user-images.githubusercontent.com/1434086/90587874-44427380-e18f-11ea-8f96-fc8c5394c782.png)

![afterrefresh](https://user-images.githubusercontent.com/1434086/90587873-44427380-e18f-11ea-9f25-1e45faa8701e.png)

Also it looks like I'm getting double disconnect messages; I'm not sure what's going on with that.

Note that you can forcibly reproduce the bug by manually wiping the userMap key out of your localstorage (though why would you do that?) - and it's null guarded such that if you do it doesn't explode.

![backwardscompatible](https://user-images.githubusercontent.com/1434086/90587876-44db0a00-e18f-11ea-838c-cc1c1cb19d65.png)

localstorage after saving:

![localstorage](https://user-images.githubusercontent.com/1434086/90587871-43a9dd00-e18f-11ea-8464-821aa37f6dae.png)

