### PR TITLE
Hook up theme selector to update the class on the body to swap CSS

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" type="text/css" href="style/style.css" />
     <script src="./src/index.tsx"></script>
   </head>
-  <body>
+  <body id="body">
     <div id="root"></div>
   </body>
 </html>

--- a/src/components/ThemeSelectorView.tsx
+++ b/src/components/ThemeSelectorView.tsx
@@ -12,7 +12,6 @@ interface Props {
 }
 
 export default function ThemeSelectorView (props: Props) {
-
     const dispatch = useContext(DispatchContext)
 
     const { defaultHandle, user} = props
@@ -37,6 +36,7 @@ export default function ThemeSelectorView (props: Props) {
     const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
         setselectedTheme(event.target.value);
         localStorage.setItem('UserSelectedTheme',event.target.value);
+        window.location.reload();
     };
     return(
         
@@ -46,24 +46,24 @@ export default function ThemeSelectorView (props: Props) {
                 <div className = "radio"><label><input 
                     type = "radio"
                     id = "theme"
-                    value = "Default"
-                    checked = {selectedTheme === 'Default'}
+                    value = "default"
+                    checked = {selectedTheme === 'default'}
                     onChange = {handleChange}
                     />
                     Default (Dark)</label></div>
                 <div className = "radio"><label><input 
                     type = "radio"
                     id = "theme"
-                    value = "SolarizedDark"
-                    checked = {selectedTheme === 'SolarizedDark'}
+                    value = "solarized-dark"
+                    checked = {selectedTheme === 'solarized-dark'}
                     onChange = {handleChange}
                     />
                     Solarized Dark</label></div>
                 <div className = "radio"><label><input 
                     type = "radio"
                     id = "theme"
-                    value = "SolarizedLight"
-                    checked = {selectedTheme === 'SolarizedLight'}
+                    value = "solarized-light"
+                    checked = {selectedTheme === 'solarized-light'}
                     onChange = {handleChange}
                     />
                     Solarized Light</label></div>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,4 +5,5 @@ import App from './App'
 
 window.addEventListener('DOMContentLoaded', () => {
   ReactDOM.render(<App />, document.getElementById('root') as HTMLElement)
+  document.getElementById("body").classList.add(localStorage.getItem('UserSelectedTheme') || 'Default');
 })


### PR DESCRIPTION
The different stylesheets are set up as linked to class names, so I'm adding a class name based on the user's style from their local storage in the index right when the DOM is loaded. No idea if that is a *good* solution.