### PR TITLE
Updated login, quick CSS var rename, Code of Conduct

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -90,15 +90,21 @@ const App = () => {
 
   if (state.checkedAuthentication && !state.authenticated) {
     return (
-      <a
-        href={`${
-          config.SERVER_HOSTNAME
-        }/.auth/login/twitter?post_login_redirect_url=${encodeURIComponent(
-          window.location.href
-        )}`}
-      >
-        Log In
-      </a>
+      <div>
+        <header role="banner"><h1>Welcome to Roguelike Celebration 2020!</h1></header>
+        <main role="main"><p>This is a social space for attendees of <a href={ 'https://roguelike.club' }>Roguelike Celebration</a>, a community-generated weekend of talks, games, and conversations about roguelikes and related topics, including procedural generation and game design. It&apos;s for fans, players, developers, scholars, and everyone else!</p>
+          <a
+            href={`${
+            config.SERVER_HOSTNAME
+          }/.auth/login/twitter?post_login_redirect_url=${encodeURIComponent(
+            window.location.href
+          )}`}
+          >
+          Log In With Twitter
+          </a>
+          <p>We are using Twitter for authentication only. You will have the opportunity to pick a distinct chat handle when you enter the space. Feel free to sign up for a free throwaway Twitter account if necessary.</p>
+          <p>By entering the space, you agree to our <a href={ 'https://roguelike.club/code.html' }>Code of Conduct</a>.</p></main>
+      </div>
     )
   }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -158,7 +158,7 @@ const App = () => {
       break
     }
     case Modal.MediaSelector: {
-      innerModalView =
+      innerModalView = (
         <MediaSelectorView
           devices={state.mediaDevices}
           initialAudioDeviceId={state.currentAudioDeviceId}
@@ -166,11 +166,14 @@ const App = () => {
           showJoinButton={!state.inMediaChat}
           userIsSpeaking={state.speakingPeerIds.includes('self')}
         />
+      )
+      break
     }
     case Modal.CodeOfConduct: {
       innerModalView = (
         <CodeOfConductView />
       )
+      break
     }
   }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import { NoteWallView } from './components/NoteWallView'
 import { ModalView } from './components/ModalView'
 import ThemeSelectorView from './components/ThemeSelectorView'
 import MediaSelectorView from './components/MediaSelectorView'
+import CodeOfConductView from './components/CodeOfConductView'
 
 export const DispatchContext = createContext(null)
 export const UserMapContext = createContext(null)
@@ -165,6 +166,11 @@ const App = () => {
           showJoinButton={!state.inMediaChat}
           userIsSpeaking={state.speakingPeerIds.includes('self')}
         />
+    }
+    case Modal.CodeOfConduct: {
+      innerModalView = (
+        <CodeOfConductView />
+      )
     }
   }
 

--- a/src/components/CodeOfConductView.tsx
+++ b/src/components/CodeOfConductView.tsx
@@ -8,14 +8,14 @@ export default function CodeOfConductView () {
   const dispatch = useContext(DispatchContext)
 
   const close = () => {
-      dispatch(HideModalAction())
+    dispatch(HideModalAction())
   }
 
   return (
     <div>
       <p>Our goal is to have a really fun and welcoming celebration of roguelike games, so we have a formalized code of conduct that sets these expectations.</p>
       <p><a href={ 'https://roguelike.club/code.html' }>Read our full Code of Conduct on our website.</a></p>
-      <p>For this event, if you're being harrassed, notice someone being harrassed, or have any other concerns related to the code of conduct, <strong>you can contact one of this event's organizers.</strong> These people are currently noted by a crown emoji next to their name. You can also use the <code>/mod</code> command to privately message all moderators.</p>
+      <p>For this event, if you&apos;re being harrassed, notice someone being harrassed, or have any other concerns related to the code of conduct, <strong>you can contact one of this event&apos;s organizers.</strong> These people are currently noted by a crown emoji 👑 next to their name. You can also use the <code>/mod</code> command to privately message all moderators.</p>
     </div>
   )
 }

--- a/src/components/CodeOfConductView.tsx
+++ b/src/components/CodeOfConductView.tsx
@@ -1,0 +1,21 @@
+import React, { useContext } from 'react'
+
+import '../../style/profileEditView.css'
+import { DispatchContext } from '../App'
+import { HideModalAction } from '../Actions'
+
+export default function CodeOfConductView () {
+  const dispatch = useContext(DispatchContext)
+
+  const close = () => {
+      dispatch(HideModalAction())
+  }
+
+  return (
+    <div>
+      <p>Our goal is to have a really fun and welcoming celebration of roguelike games, so we have a formalized code of conduct that sets these expectations.</p>
+      <p><a href={ 'https://roguelike.club/code.html' }>Read our full Code of Conduct on our website.</a></p>
+      <p>For this event, if you're being harrassed, notice someone being harrassed, or have any other concerns related to the code of conduct, <strong>you can contact one of this event's organizers.</strong> These people are currently noted by a crown emoji next to their name. You can also use the <code>/mod</code> command to privately message all moderators.</p>
+    </div>
+  )
+}

--- a/src/components/MenuButtonView.tsx
+++ b/src/components/MenuButtonView.tsx
@@ -29,6 +29,10 @@ export default function MenuButtonView (props: { username: string }) {
     dispatch(ShowModalAction(Modal.ThemeSelector))
   }
 
+  const showCodeOfConduct = () => {
+    dispatch(ShowModalAction(Modal.CodeOfConduct))
+  }
+
   return (
     <div id="menu-button">
       <ContextMenuTrigger id="topMenu" holdToDisplay={0}>
@@ -37,6 +41,7 @@ export default function MenuButtonView (props: { username: string }) {
       <ContextMenu id={'topMenu'}>
         <MenuItem onClick={showProfile}>Profile</MenuItem>
         <MenuItem onClick={showThemeSelector}>Select Theme</MenuItem>
+        <MenuItem onClick={showCodeOfConduct}>Code of Conduct</MenuItem>
         <MenuItem onClick={logOut}>Log Out</MenuItem>
       </ContextMenu>
     </div>

--- a/src/modals.ts
+++ b/src/modals.ts
@@ -4,5 +4,6 @@ export enum Modal {
     ProfileEdit,
     NoteWall,
     ThemeSelector,
-    MediaSelector
+    MediaSelector,
+    CodeOfConduct
 }

--- a/style/noteWall.css
+++ b/style/noteWall.css
@@ -10,13 +10,13 @@
 }
 
 button.note-delete {
-    color: var(--warning-color);
+    color: var(--pink);
     float: right;
     margin-left: 10px;
 }
 
 .like-button {
-    color: var(--like-color);
+    color: var(--blue);
     float: right;
     padding-left: 20px;
     padding-right: 15px;

--- a/style/room.css
+++ b/style/room.css
@@ -4,9 +4,9 @@
 }
 
 a.room-link {
-  color: var(--link-text);
+  color: var(--green);
 }
 
 a.room-link:visited {
-  color: var(--link-text);
+  color: var(--green);
 }

--- a/style/style.css
+++ b/style/style.css
@@ -7,10 +7,10 @@
   --main-font: white;
   --alternate-background: #333333;
   --alternate-translucent: rgba(51,51,51,0.8);
-  --link-text: lightseagreen;
+  --green: lightseagreen;
   --highlight-line: #aaaaaa;
-  --warning-color: lightpink;
-  --like-color: lightskyblue;
+  --pink: lightpink;
+  --blue: lightskyblue;
 }
 
 /* solarized dark */
@@ -19,10 +19,10 @@
   --main-font:#657b83;
   --alternate-background: #073642;
   --alternate-translucent: rgba(7,54,66,0.8);
-  --link-text: #859900;
+  --green: #859900;
   --highlight-line: #fdf6e3;
-  --warning-color: #d33682;
-  --like-color: #268bd2;
+  --pink: #d33682;
+  --blue: #268bd2;
 }
 
 /* solarized light */
@@ -31,10 +31,10 @@
   --main-font:#657b83;
   --alternate-background: #eee8d5;
   --alternate-translucent: rgba(238,232,213,0.8);
-  --link-text:#859900;
+  --green:#859900;
   --highlight-line: #002b36;
-  --warning-color: #d33682;
-  --like-color: #268bd2;
+  --pink: #d33682;
+  --blue: #268bd2;
 }
 
 body {
@@ -70,19 +70,19 @@ body {
 }
 
 a {
-  color:var(--link-text);
+  color:var(--green);
   text-decoration: none;
   font-weight: bold;
 }
 
 a:visited {
-  color: var(--link-text);
+  color: var(--green);
 }
 
 .link-styled-button {
   background-color: transparent;
   border: none;
-  color: var(--link-text);
+  color: var(--green);
   cursor: pointer;
   display: inline; 
   font-family: "IBM Plex Mono", "Consolas", "Courier New", Courier, monospace;

--- a/style/videoChat.css
+++ b/style/videoChat.css
@@ -14,7 +14,7 @@ input#send-audio {
 }
 
 video.speaking {
-  border: 5px solid var(--link-text);
+  border: 5px solid var(--green);
 }
 
 #media-view .video-button {


### PR DESCRIPTION
Put some content before login, regarding who we are, why we're using Twitter, and the Code of Conduct.

Added a new modal for the Code of Conduct, as well. 

Also renamed a few CSS variables, so we can reuse "green", "pink", and "blue" in other places than links/warnings/likes.

Fixes #130 and #139, maybe helps a bit for #60 (maybe we can add some more content here for folks heading in), maybe helps a prerequisite for #124 by redoing the CSS? 