### PR TITLE
Issue 173: slash command validation

### DIFF
--- a/src/SlashCommands.ts
+++ b/src/SlashCommands.ts
@@ -1,0 +1,24 @@
+interface SlashCommand {
+    name: string;
+    description: string;
+    invocations: string[];
+}
+
+const SlashCommand = (
+  name: string,
+  description: string,
+  invocations: string[]
+): SlashCommand => { return { name: name, description: description, invocations: invocations } }
+
+export const SlashCommands: SlashCommand[] = [
+  SlashCommand('move', 'Move from one room to another. You can also click on the link in the room description.', ['/go', '/move']),
+  SlashCommand('whisper', 'Whisper another user. You can also click directly on their name and select the whisper option.', ['/whisper']),
+  SlashCommand('shout', 'Sends a message to everybody at once - has a 5 minute cooldown. Do not abuse this!', ['/shout']),
+  SlashCommand('emote', 'Like a normal message, but in italics!', ['/emote', '/me']),
+  SlashCommand('contact a moderator', 'Sends a message to the mod team. We will be in touch shortly afterwards.', ['/mod', '/mods', '/moderator', '/moderators']),
+  SlashCommand('look', 'View the profile of another user. You can also click on their name and select the Profile option.', ['/look'])
+]
+
+export function matchingSlashCommand (message: String): SlashCommand | undefined {
+  return SlashCommands.find((c) => c.invocations.find((i) => message.startsWith(i)))
+}

--- a/src/SlashCommands.ts
+++ b/src/SlashCommands.ts
@@ -20,5 +20,6 @@ export const SlashCommands: SlashCommand[] = [
 ]
 
 export function matchingSlashCommand (message: String): SlashCommand | undefined {
-  return SlashCommands.find((c) => c.invocations.find((i) => message.startsWith(i)))
+  // Tacking on a required whitespace works only because we have no one-parameter commands so far!
+  return SlashCommands.find((c) => c.invocations.find((i) => message.startsWith(i + ' ')))
 }

--- a/src/reducer.ts
+++ b/src/reducer.ts
@@ -263,13 +263,14 @@ export default (oldState: State, action: Action): State => {
   // UI Actions
   if (action.type === ActionType.SendMessage) {
     const messageId: string = uuidv4()
-    const beginsWithSlash = /^\/.+?/.exec(action.value.trim())
+    const trimmedMessage = action.value.trim()
+    const beginsWithSlash = /^\/.+?/.exec(trimmedMessage)
 
-    if (beginsWithSlash && matchingSlashCommand(action.value.trim()) === undefined) {
-      const commandStr = /^(\/.+?) (.+)/.exec(action.value)
+    if (beginsWithSlash && matchingSlashCommand(trimmedMessage) === undefined) {
+      const commandStr = /^(\/.+?) (.+)/.exec(trimmedMessage)
       addMessage(state, createErrorMessage(`Your command ${commandStr ? commandStr[1] : action.value} is not a registered slash command!`))
     } else if (beginsWithSlash) {
-      sendChatMessage(messageId, action.value.trim())
+      sendChatMessage(messageId, trimmedMessage)
 
       if (beginsWithSlash[1] === 'whisper') {
         const [_, username, message] = /^(.+?) (.+)/.exec(beginsWithSlash[2])

--- a/src/reducer.ts
+++ b/src/reducer.ts
@@ -263,16 +263,16 @@ export default (oldState: State, action: Action): State => {
   // UI Actions
   if (action.type === ActionType.SendMessage) {
     const messageId: string = uuidv4()
-    const isCommand = /^\/(.+?)/.exec(action.value)
-    const matchingCommand = matchingSlashCommand(action.value)
+    const beginsWithSlash = /^\/.+?/.exec(action.value.trim())
 
-    if (isCommand && matchingCommand === undefined) {
-      addMessage(state, createChatMessage(messageId, state.userId, 'Your command is not a registered slash command!'))
-    } else if (isCommand) {
-      sendChatMessage(messageId, action.value)
+    if (beginsWithSlash && matchingSlashCommand(action.value.trim()) === undefined) {
+      const commandStr = /^(\/.+?) (.+)/.exec(action.value)
+      addMessage(state, createErrorMessage(`Your command ${commandStr ? commandStr[1] : action.value} is not a registered slash command!`))
+    } else if (beginsWithSlash) {
+      sendChatMessage(messageId, action.value.trim())
 
-      if (isCommand[1] === 'whisper') {
-        const [_, username, message] = /^(.+?) (.+)/.exec(isCommand[2])
+      if (beginsWithSlash[1] === 'whisper') {
+        const [_, username, message] = /^(.+?) (.+)/.exec(beginsWithSlash[2])
         const user = Object.values(state.userMap).find(
           (u) => u.username === username
         )

--- a/src/reducer.ts
+++ b/src/reducer.ts
@@ -270,10 +270,12 @@ export default (oldState: State, action: Action): State => {
       const commandStr = /^(\/.+?) (.+)/.exec(trimmedMessage)
       addMessage(state, createErrorMessage(`Your command ${commandStr ? commandStr[1] : action.value} is not a registered slash command!`))
     } else if (beginsWithSlash) {
+      const commandStr = /^(\/.+?) (.+)/.exec(trimmedMessage)
       sendChatMessage(messageId, trimmedMessage)
 
-      if (beginsWithSlash[1] === 'whisper') {
-        const [_, username, message] = /^(.+?) (.+)/.exec(beginsWithSlash[2])
+      // TODO clean this up by assigning enumerated values to the SlashCommands and checking against the matching command instead of this.
+      if (commandStr[1] === '/whisper') {
+        const [_, username, message] = /^(.+?) (.+)/.exec(commandStr[2])
         const user = Object.values(state.userMap).find(
           (u) => u.username === username
         )


### PR DESCRIPTION
The command list could theoretically in the future be provided by the server, but for right now it just sits on the client. This means if we add any new slash commands we also need to go add them to this structure.

I plan to also implement the /help command, which will use this object to print out the various items commands. Once that's implemented I'll add "Refer to /help or the HELP button in the upper-left corner " (if that's where it ends up) "for more info."

![Screenshot from 2020-08-28 14-44-11](https://user-images.githubusercontent.com/1434086/91617471-fec73880-e93c-11ea-9763-ba4c37f02ea0.png)
