### PR TITLE
Fixing profile/whisper to respect user style choice

### DIFF
--- a/src/components/MessageView.tsx
+++ b/src/components/MessageView.tsx
@@ -129,24 +129,18 @@ const ChatMessageView = (props: ChatMessage & { id: string }) => (
 )
 
 const WhisperView = (props: WhisperMessage & { id: string }) => {
-  const grayFont = { color: '#b5b5b5' }
-
   if (props.senderIsSelf) {
     return (
-      <div className="message" style={grayFont}>
-        <em>
-          You whisper to <NameView id={props.id} userId={props.userId} />:{' '}
-          {props.message}
-        </em>
+      <div className="whisper">
+        You whisper to <NameView id={props.id} userId={props.userId} />:{' '}
+        {props.message}
       </div>
     )
   } else {
     return (
-      <div className="message" style={grayFont}>
-        <em>
-          <NameView userId={props.userId} id={props.id} /> whispers:{' '}
-          {props.message}
-        </em>
+      <div className="whisper">
+        <NameView userId={props.userId} id={props.id} /> whispers:{' '}
+        {props.message}
       </div>
     )
   }

--- a/style/nameView.css
+++ b/style/nameView.css
@@ -36,6 +36,6 @@ span.name {
 }
 
 .name .react-contextmenu {
-  color: white;
+  color: var(--main-font);
   font-style: normal;
 }

--- a/style/profileView.css
+++ b/style/profileView.css
@@ -20,8 +20,8 @@
 }
 
 #profile {
-  background-color: black;
-  border-left: 1px solid white;
+  background-color: var(--main-background);
+  border-left: 1px solid var(--main-font);
   box-sizing: border-box;
   height: 100%;
   padding: 0px 0px 20px 20px;
@@ -36,21 +36,21 @@
 }
 
 #profile-close {
-  background-color: black;
+  background-color: var(--main-background);
   border: none;
-  color: white;
+  color: var(--main-font);
   cursor: pointer;
   font-size: 24px;
   width: 30px;
 }
 
 #chat-container {
-  border-top: 1px dashed white;
+  border-top: 1px dashed var(--main-font);
   margin-top: 20px;
 }
 
 #chat-header {
-  background-color: black;
+  background-color: var(--main-background);
   padding: 20px 0px;
   top: 0;
   width: 100%;

--- a/style/style.css
+++ b/style/style.css
@@ -5,6 +5,7 @@
 :root {
   --main-background: black;
   --main-font: white;
+  --gray-text: #b5b5b5;
   --alternate-background: #333333;
   --alternate-translucent: rgba(51,51,51,0.8);
   --green: lightseagreen;
@@ -17,6 +18,7 @@
 .solarized-dark{
   --main-background:#002b36;
   --main-font:#657b83;
+  --gray-text:#586e75;
   --alternate-background: #073642;
   --alternate-translucent: rgba(7,54,66,0.8);
   --green: #859900;
@@ -29,6 +31,7 @@
 .solarized-light{
   --main-background:#fdf6e3;
   --main-font:#657b83;
+  --gray-text:#93a1a1;
   --alternate-background: #eee8d5;
   --alternate-translucent: rgba(238,232,213,0.8);
   --green:#859900;
@@ -75,6 +78,11 @@ a {
   font-weight: bold;
 }
 
+.whisper {
+  color: var(--gray-text);
+  font-style: italic;
+}
+
 a:visited {
   color: var(--green);
 }
@@ -104,7 +112,7 @@ button {
 }
 
 input[type=radio] {
-  vertical-align: baselin;
+  vertical-align: baseline;
   margin-right: 1em;
 }
 

--- a/style/videoChat.css
+++ b/style/videoChat.css
@@ -18,16 +18,16 @@ video.speaking {
 }
 
 #media-view .video-button {
-  color: white;
+  color:var(--main-font);
   padding: 10px;
 }
 
 #media-view .video-button.enabled {
-  color: lightgreen;
+  color: var(--green);
 }
 
 #media-view .video-button.disabled {
-  color: lightpink;
+  color: var(--pink);
 }
 
 /** Selector modal */


### PR DESCRIPTION
Fixes #183 .

New behavior:
![Profile/whisper view now uses the same colors as the main side on Solarized Dark.](https://user-images.githubusercontent.com/62489292/91629834-6495dd80-e99a-11ea-86d7-9545c703c5dd.png)

Bonus:
![Clicking a username uses the correct text color, and gray text respects Solarized rules, in Solarized Light.](https://user-images.githubusercontent.com/62489292/91629851-81caac00-e99a-11ea-965d-b63688298d0e.png)

* Added .whisper class to CSS to format whispers
* Changed WhisperView to use the new .whisper class

* Made ProfileView, dropdown for names, and video chat use CSS vars