### PR TITLE
Remove determination of default selection

### DIFF
--- a/src/components/MediaSelectorView.tsx
+++ b/src/components/MediaSelectorView.tsx
@@ -52,42 +52,6 @@ export default function MediaSelectorView (props: Props) {
     startVideoChat()
   }
 
-  // Here's a fun hack!
-  // So, when opening a local MediaStream, we fetch the deviceIds for audio/video
-  // so we can preselect the correct <select> items here
-  //
-  // However, Firefox does NOT support returning that data.
-  // It can only give us the user-friendly label.
-  // So, if the deviceId isn't found in our list, we try to match based on label and grab the Id.
-  // The video and audio paths are identical.
-  console.log(props)
-  let defaultVideo = props.initialVideoDeviceId
-  if (defaultVideo) {
-    if (!videoDevices.find((v) => v.deviceId === defaultVideo)) {
-      const foundByName = videoDevices.find((v) => v.label === defaultVideo)
-      if (foundByName) {
-        defaultVideo = foundByName.deviceId
-        setVideoId(defaultVideo)
-      } else {
-        defaultVideo = undefined
-      }
-    }
-  }
-
-  let defaultAudio = props.initialAudioDeviceId
-  if (defaultAudio) {
-    if (!audioDevices.find((d) => d.deviceId === defaultAudio)) {
-      const foundByName = audioDevices.find((d) => d.label === defaultAudio)
-      if (foundByName) {
-        defaultAudio = foundByName.deviceId
-        setAudioId(defaultAudio)
-      } else {
-        defaultAudio = undefined
-      }
-    }
-  }
-  console.log(defaultAudio, defaultVideo)
-
   return (
     <div id='media-selector'>
       <LocalMediaView speaking={props.userIsSpeaking} hideUI={true}/>
@@ -97,7 +61,6 @@ export default function MediaSelectorView (props: Props) {
           name="Video"
           id="video-select"
           onChange={onVideoChange}
-          defaultValue={defaultVideo}
         >
           {videoDevices.map(deviceToOption)}
         </select>
@@ -107,7 +70,6 @@ export default function MediaSelectorView (props: Props) {
           name="Audio"
           id="audio-select"
           onChange={onAudioChange}
-          defaultValue={defaultAudio}
         >
           {audioDevices.map(deviceToOption)}
         </select>


### PR DESCRIPTION
This simply removes the code that tries to determine the default video/audio sources, which prevents the infinite render loop from happening on firefox. It's definitely able to read my webcam, and I'm 75% sure it's reading the audio.

I also tested that the video still works on Chrome and it does.

I'm not sure if removing the default gets a little wonkier if you have, like, 5 webcams hooked up? but at least it won't infinite render loop you.

I don't think this is necessarily the ultimate solution but webcam is not the focus, so "make it not kill the site" is a better.

![Screenshot from 2020-08-29 17-34-44](https://user-images.githubusercontent.com/1434086/91648621-6acd9d80-ea1e-11ea-9148-2c1766b43a51.png)
![Screenshot from 2020-08-29 17-35-03](https://user-images.githubusercontent.com/1434086/91648622-6c976100-ea1e-11ea-804c-5fb7f2f85bc2.png)
![Screenshot from 2020-08-29 17-35-15](https://user-images.githubusercontent.com/1434086/91648623-6c976100-ea1e-11ea-8e48-6ad075ea2044.png)
![Screenshot from 2020-08-29 17-35-39](https://user-images.githubusercontent.com/1434086/91648624-6d2ff780-ea1e-11ea-835b-03b3dc9e004e.png)
![Screenshot from 2020-08-29 17-36-05](https://user-images.githubusercontent.com/1434086/91648626-6d2ff780-ea1e-11ea-9d05-9879d62c78a6.png)