### PR TITLE
Moderator changes, restores user counts in sidebar, schedule change

### DIFF
--- a/src/components/CodeOfConductView.tsx
+++ b/src/components/CodeOfConductView.tsx
@@ -8,7 +8,7 @@ export default function CodeOfConductView () {
       <p>If you&apos;re being harrassed, notice someone being harrassed, or have any other concerns related to the code of conduct, you have a few options:</p>
       <ul>
         <li>Type <code>/mod</code> into the chat box, followed by a message, to contact all moderators.</li>
-        <li>Directly message any moderator with a <span className="mod">pink username</span>.</li>
+        <li>Directly message any moderator with a <span className="mod">highlighted username</span>.</li>
         <li>Email <a href="mailto:contact@roguelike.club">contact@roguelike.club</a>.</li>
         <li>If you have a report or concern related to an organizer, please contact a different member of the <a href="https://roguelike.club/who.html" target="_blank" rel="noreferrer">organizing team</a> outside of this tool (via email, Twitter DM, Discord, or some other service).</li>
       </ul>

--- a/src/components/NameView.tsx
+++ b/src/components/NameView.tsx
@@ -83,6 +83,7 @@ export default function NameView (props: { userId: string; id?: string }) {
     <span className="name" data-tip={user && user.pronouns}>
       <ContextMenuTrigger id={props.id} renderTag="span" holdToDisplay={0}>
         <strong className={isMod ? 'mod' : ''}>
+          {isMod ? '[Moderator] ' : ''}
           {username || 'unknown'}
         </strong>
       </ContextMenuTrigger>

--- a/src/components/ScheduleView.tsx
+++ b/src/components/ScheduleView.tsx
@@ -1,23 +1,49 @@
 import React from 'react'
 
 export default function ScheduleView () {
-  const dateStr = (time) => `2020-08-30T${time}:00.000-07:00`
+  const dateStr = (time) => `2020-10-03T${time}:00.000-07:00`
 
+  // To do: replace with actual speaker names
   const times = [
-    ['16:00', 'Doors Open'],
-    ['16:20', 'Kickoff'],
-    ['16:30', 'Darren Grey'],
-    ['16:40', 'Julian Day'],
-    ['16:50', 'Todd Furmanski'],
-    ['17:00', 'Tabitha Sable'],
-    ['17:10', 'Break'],
-    ['17:20', 'Gabriel Koenig'],
-    ['17:30', 'Cat Manning'],
-    ['17:40', 'Kate Comptom'],
-    ['17:50', 'Break'],
-    ['18:10', 'Preview of "Help Me Steal The Mona Lisa"'],
-    ['19:00', 'Doors Close']
+    ['09:30', 'Intro / Housekeeping'],
+    ['09:30', 'Talk 1'],
+    ['10:30', 'Talk 2'],
+    ['10:30', 'Unconferencing #1'],
+    ['11:30', 'Talk 3'],
+    ['12:30', 'Talk 4'],
+    ['12:30', 'Break'],
+    ['13:30', 'Lightning Talks'],
+    ['14:30', 'Talk 5'],
+    ['15:30', 'Talk 6'],
+    ['15:30', 'Break'],
+    ['16:30', 'Talk 7'],
+    ['16:30', 'Talk 8'],
+    ['17:30', 'Outro / Performances'],
+    ['17:30', 'Game Showcase / Unconferencing #2'],
+    ['18:30', 'Wrap']
   ]
+
+  // Including these here to be swapped in Saturday to Sunday.
+  // Again, needs to be replaced with actual speaker names
+  // const SundayTimes = [
+  //   ['09:30', 'Intro / Housekeeping'],
+  //   ['09:30', 'Lightning Talks'],
+  //   ['10:30', 'Game Showcase / Unconferencing #3'],
+  //   ['11:30', 'Talk 9'],
+  //   ['12:30', 'Talk 10'],
+  //   ['12:30', 'Break'],
+  //   ['13:30', 'Talk 11'],
+  //   ['14:30', 'Talk 12'],
+  //   ['14:30', 'Talk 13'],
+  //   ['15:30', 'Talk 14'],
+  //   ['15:30', 'Break'],
+  //   ['16:30', 'Talk 15'],
+  //   ['16:30', 'Talk 16'],
+  //   ['17:30', 'Lightning Talks'],
+  //   ['18:30', 'Outro / Performances'],
+  //   ['18:30', 'Unconferencing #4'],
+  //   ['19:30', 'Wrap']
+  // ]
 
   const formatter = new Intl.DateTimeFormat('en', { hour: 'numeric', minute: 'numeric' })
 

--- a/src/components/SideNavView.tsx
+++ b/src/components/SideNavView.tsx
@@ -65,12 +65,13 @@ const RoomListItem = (props: { room: Room }) => {
   const onClick = () => {
     moveToRoom(room.id)
   }
+  const userCount = room.users ? `(${room.users.length})` : ''
   const videoIcon = room.videoUsers && room.videoUsers.length > 0 ? <FaVideo /> : ''
 
   return (
     <li>
       <button onClick={onClick}>
-        <strong>{room.name}</strong> {videoIcon}
+        <strong>{room.name}</strong> {userCount} {videoIcon}
       </button>
     </li>
   )

--- a/style/chat.css
+++ b/style/chat.css
@@ -1,5 +1,6 @@
 #messages {
   height: 40vh;
   overflow-y: auto;
+  overflow-x: hidden;
   -webkit-overflow-scrolling: touch;
 }

--- a/style/nameView.css
+++ b/style/nameView.css
@@ -41,5 +41,6 @@ span.name {
 }
 
 .mod {
-  color: var(--pink);
+  background-color: var(--highlight-line);
+  color: var(--main-text);
 }

--- a/style/profileView.css
+++ b/style/profileView.css
@@ -57,7 +57,8 @@
 }
 
 #chat {
-  overflow: scroll;
+  overflow-y: auto;
+  overflow-x: hidden;
   height: 40vh;
 }
 

--- a/style/style.css
+++ b/style/style.css
@@ -9,7 +9,7 @@
   --alternate-background: #333333;
   --alternate-translucent: rgba(51,51,51,0.8);
   --green: lightseagreen;
-  --highlight-line: #aaaaaa;
+  --highlight-line: #888888;
   --pink: lightpink;
   --blue: lightskyblue;
 }


### PR DESCRIPTION
Closes #196 
* Moderators now have both '[Moderator] ' before their username and are highlighted in a high-contrast way versus normal users
![In 'Default' theme, the moderator has a gray background.](https://user-images.githubusercontent.com/62489292/91902555-e8d4b300-ec6f-11ea-97b7-470e2edd6427.png)
![In 'Solarized Dark' theme, the moderator has a pale background, the background of 'Solarized Light'.](https://user-images.githubusercontent.com/62489292/91902613-ff7b0a00-ec6f-11ea-9ad8-5378311e978c.png)
![The colors all flip for the 'Solarized Light' theme.](https://user-images.githubusercontent.com/62489292/91902677-17eb2480-ec70-11ea-931a-db4337e4d53d.png)

* This is also reflected in Code of Conduct text.

Closes #213
* Restore user counts on sidebar

Also updated the schedule to not be that of the preview - but will need to be fixed again when we determine speaker order