### PR TITLE
Issue 192: slash command improvements

### DIFF
--- a/src/components/MessageView.tsx
+++ b/src/components/MessageView.tsx
@@ -18,7 +18,8 @@ import {
   ErrorMessage,
   ShoutMessage,
   EmoteMessage,
-  ModMessage
+  ModMessage,
+  CommandMessage
 } from '../message'
 import NameView from './NameView'
 import { UserMapContext } from '../App'
@@ -42,7 +43,8 @@ export default function MessageView (props: { message: Message; id: string, hide
     [MessageType.Shout]: ShoutView,
     [MessageType.Emote]: EmoteView,
     [MessageType.Error]: ErrorView,
-    [MessageType.Mod]: ModMessageView
+    [MessageType.Mod]: ModMessageView,
+    [MessageType.Command]: CommandView
   }
 
   const component = messageMap[message.type]
@@ -204,4 +206,8 @@ const EmoteView = (props: EmoteMessage & { id: string }) => {
 
 const ErrorView = (props: ErrorMessage & { id: string }) => {
   return <div className="message">{props.error}</div>
+}
+
+const CommandView = (props: CommandMessage & { id: string }) => {
+  return <div className="message"><em>{props.command}</em></div>
 }

--- a/src/components/MessageView.tsx
+++ b/src/components/MessageView.tsx
@@ -205,7 +205,7 @@ const EmoteView = (props: EmoteMessage & { id: string }) => {
 }
 
 const ErrorView = (props: ErrorMessage & { id: string }) => {
-  return <div className="message">{props.error}</div>
+  return <div className="error">{props.error}</div>
 }
 
 const CommandView = (props: CommandMessage & { id: string }) => {

--- a/src/message.ts
+++ b/src/message.ts
@@ -10,7 +10,8 @@ export type Message =
   | ShoutMessage
   | EmoteMessage
   | ModMessage
-  | ErrorMessage;
+  | ErrorMessage
+  | CommandMessage;
 
 export enum MessageType {
   Connected = 'CONNECTED',
@@ -25,6 +26,7 @@ export enum MessageType {
   Emote = 'EMOTE',
   Mod = 'MOD',
   Error = 'ERROR',
+  Command = 'COMMAND',
 }
 
 export function isDeletable (message: Message): message is ChatMessage | EmoteMessage | ShoutMessage {
@@ -186,4 +188,14 @@ export interface ErrorMessage {
 
 export const createErrorMessage = (error: string): ErrorMessage => {
   return { type: MessageType.Error, error, timestamp: new Date() }
+}
+
+export interface CommandMessage {
+  type: MessageType.Command;
+  command: string;
+  timestamp: Date;
+}
+
+export const createCommandMessage = (command: string): CommandMessage => {
+  return { type: MessageType.Command, command, timestamp: new Date() }
 }

--- a/src/reducer.ts
+++ b/src/reducer.ts
@@ -281,16 +281,22 @@ export default (oldState: State, action: Action): State => {
       const commandStr = /^(\/.+?) (.+)/.exec(trimmedMessage)
       addMessage(state, createErrorMessage(`Your command ${commandStr ? commandStr[1] : action.value} is not a registered slash command!`))
     } else if (beginsWithSlash && matching.type === SlashCommandType.Whisper) {
-      sendChatMessage(messageId, trimmedMessage)
-
       const commandStr = /^(\/.+?) (.+)/.exec(trimmedMessage)
-      const [_, username, message] = /^(.+?) (.+)/.exec(commandStr[2])
-      const user = Object.values(state.userMap).find(
-        (u) => u.username === username
-      )
-      const userId = user && user.id
-      if (userId) {
-        addMessage(state, createWhisperMessage(userId, message, true))
+      const parsedUsernameMessage = /^(.+?) (.+)/.exec(commandStr[2])
+
+      if (!parsedUsernameMessage) {
+        addMessage(state, createErrorMessage(`Your whisper to ${commandStr[2]} had no message!`))
+      } else {
+        sendChatMessage(messageId, trimmedMessage)
+
+        const [_, username, message] = parsedUsernameMessage
+        const user = Object.values(state.userMap).find(
+          (u) => u.username === username
+        )
+        const userId = user && user.id
+        if (userId) {
+          addMessage(state, createWhisperMessage(userId, message, true))
+        }
       }
     } else if (beginsWithSlash && matching.type === SlashCommandType.Help) {
       state.activeModal = Modal.Help

--- a/style/style.css
+++ b/style/style.css
@@ -83,6 +83,11 @@ a {
   font-style: italic;
 }
 
+.error {
+  color: var(--pink);
+  font-style: italic;
+}
+
 a:visited {
   color: var(--green);
 }


### PR DESCRIPTION
#192 and #201 and also some extra feedback

Viewer perspective:

![Screenshot from 2020-09-07 20-44-18](https://user-images.githubusercontent.com/1434086/92431016-4030c280-f14b-11ea-9ead-ec7968e2bd02.png)

Typer perspective:

![Screenshot from 2020-09-07 20-47-06](https://user-images.githubusercontent.com/1434086/92431084-68202600-f14b-11ea-87f5-06d4c9f2df5e.png)

We should probably have the error messages in a different color/contrast.