### PR TITLE
Issue 206: local dm persistence

### DIFF
--- a/src/Actions.ts
+++ b/src/Actions.ts
@@ -3,7 +3,7 @@ import { State } from './reducer'
 import { fetchProfile } from './networking'
 import { PublicUser, MinimalUser } from '../server/src/user'
 import { Room } from './room'
-import { Message } from './message'
+import { Message, WhisperMessage } from './message'
 import { RoomNote } from '../server/src/roomNote'
 import { Modal } from './modals'
 import { getMediaStream } from './webRTC'
@@ -641,10 +641,11 @@ export const ModToggleAction = (userId: string): ModToggleAction => {
 interface LoadMessageArchiveAction {
   type: ActionType.LoadMessageArchive;
   messages: Message[];
+  whispers: WhisperMessage[];
 }
 
-export const LoadMessageArchiveAction = (messages: Message[]): LoadMessageArchiveAction => {
-  return { type: ActionType.LoadMessageArchive, messages: messages }
+export const LoadMessageArchiveAction = (messages: Message[], whispers: WhisperMessage[]): LoadMessageArchiveAction => {
+  return { type: ActionType.LoadMessageArchive, messages: messages, whispers: whispers }
 }
 
 interface NoteAddAction {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -61,6 +61,7 @@ const App = () => {
           let localLocalData = false
           const rawTimestamp = localStorage.getItem('messageTimestamp')
           const rawMessageData = localStorage.getItem('messages')
+          const rawWhisperData = localStorage.getItem('whispers')
           if (rawTimestamp) {
             try {
               const timestamp = new Date(rawTimestamp)
@@ -76,7 +77,8 @@ const App = () => {
           if (localLocalData) {
             try {
               const messages = JSON.parse(rawMessageData)
-              dispatch(LoadMessageArchiveAction(messages))
+              const whispers = JSON.parse(rawWhisperData)
+              dispatch(LoadMessageArchiveAction(messages, whispers))
             } catch (e) {
               console.log('Could not parse message JSON', e)
             }
@@ -94,7 +96,7 @@ const App = () => {
   const isMobile = window.outerWidth < 500
 
   const profile = state.visibleProfile ? (
-    <ProfileView user={state.visibleProfile} messages={state.messages} />
+    <ProfileView user={state.visibleProfile} whispers={state.whispers} />
   ) : (
     ''
   )

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,6 +30,7 @@ import HelpView from './components/HelpView'
 import MapModalView from './components/MapModalView'
 import LoggedOutView from './components/LoggedOutView'
 import WelcomeModalView from './components/WelcomeModalView'
+import { WhisperMessage } from './message'
 
 export const DispatchContext = createContext(null)
 export const UserMapContext = createContext(null)
@@ -77,7 +78,7 @@ const App = () => {
           if (localLocalData) {
             try {
               const messages = JSON.parse(rawMessageData)
-              const whispers = JSON.parse(rawWhisperData)
+              const whispers = JSON.parse(rawWhisperData) || new Array<WhisperMessage>()
               dispatch(LoadMessageArchiveAction(messages, whispers))
             } catch (e) {
               console.log('Could not parse message JSON', e)

--- a/src/components/ProfileView.tsx
+++ b/src/components/ProfileView.tsx
@@ -37,8 +37,8 @@ const ProfileWhisperView = (props: WhisperMessage & {id: string, otherUser: Publ
   }
 }
 
-export default function ProfileView (props: { user: PublicUser, messages: Message[] }) {
-  const { user, messages } = props
+export default function ProfileView (props: { user: PublicUser, whispers: WhisperMessage[] }) {
+  const { user, whispers } = props
   const dispatch = useContext(DispatchContext)
 
   React.useEffect(() => {
@@ -55,7 +55,7 @@ export default function ProfileView (props: { user: PublicUser, messages: Messag
       (lastMessage.parentNode as any).offsetTop
   })
 
-  const whisperMessages = messages.filter((m, _) => m.type === MessageType.Whisper && m.userId === user.id) as Array<WhisperMessage>
+  const whisperMessages = whispers.filter((m, _) => m.userId === user.id) as Array<WhisperMessage>
 
   const realName = user.realName ? (
     <div id="profile-realName">{user.realName}</div>


### PR DESCRIPTION
Because the `messages` key in localStorage is now capped, this stores the DMs in a different key. You could theoretically run into similar performance problems by DMing way too much, or if somebody like...scripts a bot to DM you, but this covers most cases.

It notably doesn't let you sync across different machines/browsers, but it will sync across different tabs of the same browser, like how all the rest of our messages work.

We could go for the Full Server Experience if we like, but I think this is minimally sufficient to let us go ahead with the localStorage cap.

Demonstrating that whispers are written:

![Screenshot from 2020-09-22 19-15-23](https://user-images.githubusercontent.com/1434086/93957134-7e5fe180-fd08-11ea-8cb3-015d6ee915a5.png)

Demonstrating that whispers are read independently of messages, and are pulled up in the profile/whisper view:

![Screenshot from 2020-09-22 19-16-01](https://user-images.githubusercontent.com/1434086/93957133-7d2eb480-fd08-11ea-948e-bdd568c33d5b.png)
