### PR TITLE
Issue 197: chat links new window

### DIFF
--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -5,8 +5,6 @@ import { Message, MessageType } from '../message'
 
 import '../../style/chat.css'
 
-console.log('Are we linkify9ing?')
-
 export default function ChatView (props: { messages: Message[] }) {
   React.useEffect(() => {
     const lastMessage = document.querySelector(

--- a/src/components/MessageView.tsx
+++ b/src/components/MessageView.tsx
@@ -74,15 +74,21 @@ type DeletableMessageViewProps = {
   messageId: string
 }
 
+const linkDecorator = (href, text, key) => (
+  <a href={href} key={key} target="_blank" rel="noopener noreferrer">
+    {text}
+  </a>
+)
+
 const DeletableMessageView: FunctionComponent<DeletableMessageViewProps> = (props) => {
   const { userMap, myId } = useContext(UserMapContext)
   const playerIsMod = userMap[myId] && userMap[myId].isMod
 
   if (!playerIsMod) {
-    return <Linkify properties={{ target: '_blank' }}>{props.children}</Linkify>
+    return <Linkify componentDecorator={linkDecorator}>{props.children}</Linkify>
   } else {
     return (
-      <Linkify properties={{ target: '_blank' }}>
+      <Linkify componentDecorator={linkDecorator}>
         <span className="deleteMenu">
           <ContextMenuTrigger id={props.messageId} mouseButton={2} renderTag="span">
             {props.children}

--- a/src/components/NoteView.tsx
+++ b/src/components/NoteView.tsx
@@ -39,8 +39,14 @@ export function NoteView (props: { note: RoomNote }) {
     }
   }
 
+  const linkDecorator = (href, text, key) => (
+    <a href={href} key={key} target="_blank" rel="noopener noreferrer">
+      {text}
+    </a>
+  )
+
   return (
-    <Linkify properties={{ target: '_blank' }}>
+    <Linkify componentDecorator={linkDecorator}>
       <div className='note'>
         {canDelete ? <button onClick={onClickDelete} className='link-styled-button note-delete'>X</button> : ''}
         {n.message} <br/>

--- a/src/components/ProfileView.tsx
+++ b/src/components/ProfileView.tsx
@@ -98,8 +98,14 @@ export default function ProfileView (props: { user: PublicUser, whispers: Whispe
     null
   )
 
+  const linkDecorator = (href, text, key) => (
+    <a href={href} key={key} target="_blank" rel="noopener noreferrer">
+      {text}
+    </a>
+  )
+
   return (
-    <Linkify>
+    <Linkify componentDecorator={linkDecorator}>
       <div id="profile">
         <div id="header">
           <h2 className={user.isMod ? 'mod' : ''}>{user.username} {user.isMod ? <div>(moderator)</div> : ''}</h2>


### PR DESCRIPTION
Note the target="_blank" in the element (I did click it and it opened in new window too I just don't have my gif recorder on my laptop)

Chat view:

![Screenshot from 2020-09-24 10-28-38](https://user-images.githubusercontent.com/1434086/94179148-f33e3300-fe50-11ea-8897-630a88fa3be1.png)

Profile view: (somewhat hilariously you can make your name a link, probably should fix that or something)

![Screenshot from 2020-09-24 10-38-16](https://user-images.githubusercontent.com/1434086/94180130-61cfc080-fe52-11ea-972d-559a745a46bb.png)

This does importantly *not* make your chat name a link:

![Screenshot from 2020-09-24 10-38-42](https://user-images.githubusercontent.com/1434086/94180132-61cfc080-fe52-11ea-93d7-5afc554b46ee.png)

Note view link:

![Screenshot from 2020-09-24 10-39-21](https://user-images.githubusercontent.com/1434086/94180133-62685700-fe52-11ea-9452-c15b7095de68.png)
