### PR TITLE
Issue 205: Add more granular whisper error messages

### DIFF
--- a/server/src/user.ts
+++ b/server/src/user.ts
@@ -52,9 +52,6 @@ export async function getUserIdForOnlineUsername (username: string) {
 }
 
 export async function getUserIdForUsername (username: string) {
-  // This currently only checks active users, by intention
-  // If we used all users, that would mistakenly let you e.g. send messages to offline users
-  // (who would never get the message)
   const userMap = await DB.minimalProfileUserMap()
   const user = Object.values(userMap).find((u) => u.username === username)
   if (user) {

--- a/server/src/whisper.ts
+++ b/server/src/whisper.ts
@@ -1,6 +1,6 @@
 import { Context } from '@azure/functions'
 
-import { User, getUserIdForOnlineUsername } from './user'
+import { User, getUserIdForOnlineUsername, getUserIdForUsername } from './user'
 
 export async function whisper (
   from: User,
@@ -8,10 +8,20 @@ export async function whisper (
   message: string,
   context: Context
 ) {
-  const toUser = await getUserIdForOnlineUsername(toUsername)
+  const toUser = await getUserIdForUsername(toUsername)
+  const toUserIsOnline = await getUserIdForOnlineUsername(toUsername)
 
   // TODO: Return this as metadata so the client can NameView the username
+  // Also: I think maybe a 404 is a better error code? but we can worry about that later if at all.
   if (!toUser) {
+    context.res = {
+      status: 200,
+      body: {
+        error: `${toUsername} does not match any usernames! You may also get this if the username was previously correct, but the user has changed their name since.`
+      }
+    }
+    return
+  } else if (!toUserIsOnline) {
     context.res = {
       status: 200,
       body: {


### PR DESCRIPTION
There's now a distinction between "no such user" and "user is offline". I don't know if this was what was happening but at least it eliminates one really easy source of false positives.

![Screenshot from 2020-09-24 13-49-58](https://user-images.githubusercontent.com/1434086/94199125-30b0b980-fe6d-11ea-8b28-28e5c2ce91d6.png)
