### PR TITLE
Make padding, gap, right margin scale

### DIFF
--- a/style/style.css
+++ b/style/style.css
@@ -47,17 +47,17 @@ body {
 }
 
 #app {
-  padding: 0 50px;
+  padding: 0 3%;
   display: grid;
-  grid-template-columns: 250px 1fr 200px;
-  grid-gap: 50px;
+  grid-template-columns: 250px 5fr 1fr;
+  grid-gap: 3%;
 }
 
 #app-profile-open {
-  padding: 0 50px;
+  padding: 0 3%;
   display: grid;
-  grid-template-columns: 250px 1fr 400px;
-  grid-gap: 50px;
+  grid-template-columns: 250px 5fr 400px;
+  grid-gap: 3%;
 }
 
 @media only screen and (max-device-width: 500px) {


### PR DESCRIPTION
Mostly this is an issue when you view at lower resolutions - have 200px
on the right side + 50px width & padding is a LOT of wasted space when
you downscale your browser.

With fixed margins & padding & right column:

![Screenshot from 2020-09-24 14-45-45](https://user-images.githubusercontent.com/1434086/94204007-4d50ef80-fe75-11ea-93bc-6488edbd06b8.png)
![Screenshot from 2020-09-24 14-46-03](https://user-images.githubusercontent.com/1434086/94204009-4e821c80-fe75-11ea-905c-9d091f1fb46d.png)

With variable margins & padding & right column:

![Screenshot from 2020-09-24 14-47-40](https://user-images.githubusercontent.com/1434086/94204010-4e821c80-fe75-11ea-891c-56027fde69a6.png)
![Screenshot from 2020-09-24 14-47-59](https://user-images.githubusercontent.com/1434086/94204011-4f1ab300-fe75-11ea-9a66-2fd9b666bcf9.png)
