### PR TITLE
Make onboarding form more mobile friendly

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  	<meta name="viewport" content="width=device-width, initial-scale=1">
     <meta http-equiv="Content-Type" content="text/html" charset="utf-8" />
     <title>Yet Another Browser MUD</title>
 

--- a/style/modal.css
+++ b/style/modal.css
@@ -21,7 +21,8 @@
     top: 5vh;
     left: 0;
     right: 0;
-    width: 800px;
+    width: 100%;
+    max-width: 800px;
 }
 
 #close-button {

--- a/style/profileEditView.css
+++ b/style/profileEditView.css
@@ -30,6 +30,7 @@ input[type=text] {
 }
 
 .form {
+  width: 100%;
   width: 780px;
 }
 
@@ -53,9 +54,9 @@ input[type=text] {
 .grid {
   display: grid;
   grid-column-gap: 5%;
-  grid-template-columns: 47.5% 47.5%;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
   grid-template-rows: repeat(3, 1fr)
-}
+} 
 
 #profile-edit .submit {
   float: right;

--- a/style/profileEditView.css
+++ b/style/profileEditView.css
@@ -65,3 +65,18 @@ input[type=text] {
 #profile-edit h1 {
     margin-top: 0;
 }
+
+
+@media only screen and (max-width: 600px) {
+  #profile-edit .field {
+    margin-bottom: 2rem;
+  }
+
+  .ftue .form {
+    margin-top: 1rem;
+  }
+
+  #profile-edit em {
+    line-height: 2em;
+  }
+}

--- a/style/profileView.css
+++ b/style/profileView.css
@@ -9,6 +9,10 @@
     top: 0;
     width: 100vw;
   }
+
+  #profile input {
+    width: 30px;
+  }
 }
 
 #profile .close-profile {
@@ -67,5 +71,6 @@
 }
 
 input {
+  box-sizing: border-box;
   width: 100%;
 }

--- a/style/room.css
+++ b/style/room.css
@@ -34,3 +34,7 @@ a.room-link:visited {
   border-color: var(--highlight-line);
   padding-top: 5px;
 }
+
+#static-room-description iframe {
+  max-width: 100%;
+}

--- a/style/style.css
+++ b/style/style.css
@@ -53,6 +53,13 @@ body {
   grid-gap: 50px;
 }
 
+@media only screen and (max-device-width: 500px) {
+  #app {
+    padding: 5px;
+    box-sizing: border-box;
+  }
+}
+
 #app-profile-open {
   padding: 0 50px;
   display: grid;


### PR DESCRIPTION
Hi, I'd like to make some of the CSS more mobile-friendly if that's okay.

**Onboarding form** 

on mobile before changes: 

<img width="615" alt="Screen Shot 2020-09-24 at 6 53 11 PM" src="https://user-images.githubusercontent.com/4978373/94220675-60c48080-fe9e-11ea-89c4-b224b665d635.png">

with changes:

<img width="553" alt="Screen Shot 2020-09-24 at 6 51 43 PM" src="https://user-images.githubusercontent.com/4978373/94220694-6b7f1580-fe9e-11ea-89d4-fd9dbe605840.png">

**South showcase**

before changes: 

<img width="442" alt="Screen Shot 2020-09-25 at 2 05 50 PM" src="https://user-images.githubusercontent.com/4978373/94316334-ff052480-ff38-11ea-90b9-73bad7ea195b.png">


<img width="427" alt="Screen Shot 2020-09-25 at 2 05 57 PM" src="https://user-images.githubusercontent.com/4978373/94316201-cc5b2c00-ff38-11ea-9b39-f27f49b81734.png">


with changes: 

<img width="451" alt="Screen Shot 2020-09-25 at 2 04 29 PM" src="https://user-images.githubusercontent.com/4978373/94316261-e3018300-ff38-11ea-9724-9fcdafde1ac7.png">

<img width="489" alt="Screen Shot 2020-09-25 at 2 04 36 PM" src="https://user-images.githubusercontent.com/4978373/94316278-e98ffa80-ff38-11ea-9b6e-4cb7748e8efe.png">


