### PR TITLE
Make side nav scrollable on mobile

### DIFF
--- a/style/nav.css
+++ b/style/nav.css
@@ -12,6 +12,8 @@
     height: 100vh;
     top: 0;
     width: 100vw;
+    overflow: scroll;
+    margin-top: 0;
   }
 
   #side-menu #close-button {


### PR DESCRIPTION
Pretty minor, the side nav didn't scroll on mobile and now it does. 

<img width="432" alt="Screen Shot 2020-09-25 at 9 24 27 PM" src="https://user-images.githubusercontent.com/4978373/94330155-8624bd80-ff76-11ea-8e6a-840c3327e575.png">

<img width="428" alt="Screen Shot 2020-09-25 at 9 32 02 PM" src="https://user-images.githubusercontent.com/4978373/94330160-9d63ab00-ff76-11ea-91fc-c8bedc93a6d1.png">
