### PR TITLE
Show explicit Twitter field in profile edit

### DIFF
--- a/server/updateProfile/index.ts
+++ b/server/updateProfile/index.ts
@@ -22,12 +22,6 @@ const httpTrigger: AzureFunction = async function (
     return
   }
 
-  const twitterHandle =
-    req.headers && req.headers['x-ms-client-principal-name']
-  if (twitterHandle) {
-    data.twitterHandle = twitterHandle
-  }
-
   const profile = await updateUserProfile(userId, data)
   const minimalUser = minimizeUser(profile)
 

--- a/src/Actions.ts
+++ b/src/Actions.ts
@@ -623,7 +623,7 @@ export const HideModalAction = (): HideModalAction => {
 
 interface AuthenticateAction {
   type: ActionType.Authenticate;
-  value: { name: string; userId: string };
+  value: { name: string; userId: string, provider: string };
 }
 
 interface ShowSideMenuAction {
@@ -660,9 +660,10 @@ export const ActivateAutoscrollAction = (): ActivateAutoscrollAction => {
 
 export const AuthenticateAction = (
   userId: string | undefined,
-  name: string | undefined
+  name: string | undefined,
+  provider: string | undefined
 ): AuthenticateAction => {
-  return { type: ActionType.Authenticate, value: { userId, name } }
+  return { type: ActionType.Authenticate, value: { userId, name, provider } }
 }
 
 interface IsRegisteredAction {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -51,20 +51,20 @@ const App = () => {
     const login = getLoginInfo().then((login) => {
       if (!login) {
         // This should really be its own action distinct from logging in
-        dispatch(AuthenticateAction(undefined, undefined))
+        dispatch(AuthenticateAction(undefined, undefined, undefined))
       } else {
         console.log(login)
         const userId = login.user_claims.find(c => c.typ === 'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier').val
 
         checkIsRegistered().then(({ registeredUsername, spaceIsClosed, isMod, isBanned }) => {
           if (!registeredUsername) {
-            dispatch(AuthenticateAction(userId, login.user_id))
+            dispatch(AuthenticateAction(userId, login.user_id, login.provider_name))
             return
           }
-          dispatch(AuthenticateAction(userId, registeredUsername))
+          dispatch(AuthenticateAction(userId, registeredUsername, login.provider_name))
 
           if (isBanned) {
-            dispatch(PlayerBannedAction({id: userId, username: registeredUsername, isBanned: isBanned}))
+            dispatch(PlayerBannedAction({ id: userId, username: registeredUsername, isBanned: isBanned }))
             dispatch(IsRegisteredAction())
             return
           }
@@ -137,6 +137,7 @@ const App = () => {
         isFTUE={true}
         defaultHandle={state.userMap[state.userId].username}
         user={state.profileData}
+        prepopulateTwitterWithDefaultHandle={state.authenticationProvider === 'twitter'}
       />
     )
   }

--- a/src/components/ProfileEditView.tsx
+++ b/src/components/ProfileEditView.tsx
@@ -10,6 +10,7 @@ import { HideModalAction } from '../Actions'
 interface Props {
   isFTUE: boolean;
   defaultHandle?: string;
+  prepopulateTwitterWithDefaultHandle?: boolean
   user?: PublicUser;
 }
 
@@ -28,7 +29,7 @@ function crushSpaces (s: string) : string {
 export default function ProfileEditView (props: Props) {
   const dispatch = useContext(DispatchContext)
 
-  const { defaultHandle, user } = props
+  const { defaultHandle, user, prepopulateTwitterWithDefaultHandle } = props
 
   const [handle, setHandle] = useState(
     (user && user.username) || defaultHandle || ''
@@ -40,6 +41,10 @@ export default function ProfileEditView (props: Props) {
   )
   const [askMeAbout, setAskMeAbout] = useState((user && user.askMeAbout) || '')
   const [url, setUrl] = useState((user && user.url) || '')
+  const [twitter, setTwitter] = useState(
+    (user && user.twitterHandle) ||
+    (prepopulateTwitterWithDefaultHandle && defaultHandle) ||
+    '')
 
   const close = () => {
     dispatch(HideModalAction())
@@ -52,6 +57,7 @@ export default function ProfileEditView (props: Props) {
       pronouns,
       description,
       askMeAbout,
+      twitterHandle: twitter,
       url
     },
     props.isFTUE)
@@ -94,16 +100,6 @@ export default function ProfileEditView (props: Props) {
             />
           </div>
           <div className="field">
-            <label htmlFor="pronouns">Pronouns</label>
-            <em>e.g. "she/her" or "he/they"</em>
-            <input
-              type="text"
-              id="pronouns"
-              value={pronouns}
-              onChange={(e) => setPronouns(e.currentTarget.value)}
-            />
-          </div>
-          <div className="field">
             <label htmlFor="description">Character Description</label>
             <em>Describe your virtual avatar!</em>
             <input
@@ -114,13 +110,33 @@ export default function ProfileEditView (props: Props) {
             />
           </div>
           <div className="field">
+            <label htmlFor="pronouns">Pronouns</label>
+            <em>e.g. "she/her" or "he/they"</em>
+            <input
+              type="text"
+              id="pronouns"
+              value={pronouns}
+              onChange={(e) => setPronouns(e.currentTarget.value)}
+            />
+          </div>
+          <div className="field">
             <label htmlFor="website">Website</label>
-            <em>Your personal site, or something else</em>
+            <em>Your personal site or something else</em>
             <input
               type="text"
               id="website"
               value={url}
               onChange={(e) => setUrl(e.currentTarget.value)}
+            />
+          </div>
+          <div className="field">
+            <label htmlFor="twitter">Twitter Handle</label>
+            <em>You don't need to include the @</em>
+            <input
+              type="text"
+              id="twitter"
+              value={twitter}
+              onChange={(e) => setTwitter(e.currentTarget.value)}
             />
           </div>
           <div className="field">

--- a/src/reducer.ts
+++ b/src/reducer.ts
@@ -34,6 +34,7 @@ import { MAX_MESSAGE_LENGTH } from '../server/src/config'
 export interface State {
   authenticated: boolean;
   checkedAuthentication: boolean;
+  authenticationProvider?: string;
 
   hasRegistered: boolean;
 
@@ -240,7 +241,7 @@ export default (oldState: State, action: Action): State => {
       state.isBanned = true
     } else {
       state.userMap[action.value.id].isBanned = true
-      addMessage(state, createErrorMessage("User " + action.value.username + " was banned!"))
+      addMessage(state, createErrorMessage('User ' + action.value.username + ' was banned!'))
     }
   }
 
@@ -249,7 +250,7 @@ export default (oldState: State, action: Action): State => {
     if (state.userMap[action.value.id]) {
       state.userMap[action.value.id].isBanned = false
     }
-    addMessage(state, createErrorMessage("User " + action.value.username + " was unbanned!"))
+    addMessage(state, createErrorMessage('User ' + action.value.username + ' was unbanned!'))
   }
 
   if (action.type === ActionType.Error) {
@@ -391,6 +392,8 @@ export default (oldState: State, action: Action): State => {
 
   if (action.type === ActionType.Authenticate) {
     state.checkedAuthentication = true
+
+    state.authenticationProvider = action.value.provider
 
     if (action.value.userId && action.value.name) {
       state.authenticated = true


### PR DESCRIPTION
In #270, we were showing Google users' emails instead of their Twitter handles in the appropriate field.

This changes the profile edit flow to do two things:

1. "Twitter handle" is an explicit editable field
2. If the user authed via Twitter, it's prepopulated with their authed handle on initial creation

The latter hasn't yet been tested. I need to make a new Twitter account or delete my other test one from the DB before I merge this.