### PR TITLE
Iframe css fix

### DIFF
--- a/server/src/rooms/theater.ts
+++ b/server/src/rooms/theater.ts
@@ -12,7 +12,7 @@ export default {
           <iframe id="captions" width="560" height="100" src="https://www.streamtext.net/player/?event=RoguelikeCelebration&chat=false&header=false&footer=false&indicator=false&ff=Consolas&fgc=93a1a1" frameborder="0" allow="autoplay; encrypted-media;" allowfullscreen></iframe>
         </div>
         <br/>
-        <a href="stream.html" onClick="window.open(\'stream.html#\' + window.getComputedStyle(document.body).getPropertyValue(\'background-color\'), \'stream\', \'width=560,height=450\'); return false">Pop Out Stream</a><br/>
+        <a href="stream.html" onClick="window.open(\'stream.html#\' + window.getComputedStyle(document.body).getPropertyValue(\'background-color\'), \'stream\', \'width=560,height=460\'); return false">Pop Out Stream</a><br/>
         `,
   allowsMedia: true,
   hasNoteWall: true,

--- a/server/src/rooms/theater.ts
+++ b/server/src/rooms/theater.ts
@@ -7,8 +7,10 @@ export default {
         A stage, confusingly decorated with Halloween skulls and streamers. There are a few dozen flimsy metal chairs you can sit in, plus some comfy couches in the back. 
         You can leave to the [[kitchen]], the [[bar]], the [[lounge]], the [[foyer]], the [[north showcase hall->northShowcaseHall]], or clamber into the [[shipping container->shippingContainer]].
         <br/><br/>
-        <center id="iframes"><iframe width="560" height="315" src="https://player.twitch.tv/?channel=roguelike_con&parent=chat.roguelike.club" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-        <iframe id="captions" width="560" height="100" src="https://www.streamtext.net/player/?event=RoguelikeCelebration&chat=false&header=false&footer=false&indicator=false&ff=Consolas&fgc=93a1a1" frameborder="0" allow="autoplay; encrypted-media;" allowfullscreen></iframe></center>
+        <div id="iframes" style="margin: auto;">
+          <iframe width="560" height="315" src="https://player.twitch.tv/?channel=roguelike_con&parent=chat.roguelike.club" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+          <iframe id="captions" width="560" height="100" src="https://www.streamtext.net/player/?event=RoguelikeCelebration&chat=false&header=false&footer=false&indicator=false&ff=Consolas&fgc=93a1a1" frameborder="0" allow="autoplay; encrypted-media;" allowfullscreen></iframe>
+        </div>
         <br/>
         <a href="stream.html" onClick="window.open(\'stream.html#\' + window.getComputedStyle(document.body).getPropertyValue(\'background-color\'), \'stream\', \'width=560,height=450\'); return false">Pop Out Stream</a><br/>
         `,

--- a/stream.html
+++ b/stream.html
@@ -3,11 +3,25 @@
     <title>Roguelike Celebration Stream</title>
   </head>
 </html>
+
 <body style='overflow-x: hidden'>
-  <center>
-  <iframe width="560" height="315" src="https://player.twitch.tv/?channel=roguelike_con&parent=chat.roguelike.club" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen />
-  <iframe id="captions" width="560" height="100" src="https://www.streamtext.net/player/?event=RoguelikeCelebration&chat=false&header=false&footer=false&indicator=false&ff=Consolas&fgc=93a1a1" frameborder="0" allow="autoplay; encrypted-media;" allowfullscreen />
-  </center>
+  <div style="height: 100%; display: flex; flex-flow: column;">
+    <div style="height: 0; width: 100%; position: relative; padding-bottom: 56.25%">
+      <iframe id="embed"
+        src="https://player.twitch.tv/?channel=roguelike_con&parent=chat.roguelike.club"
+        frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
+        allowfullscreen
+        style="width: 100%; position: absolute; height: 100%; left: 0; top: 0;"
+      ></iframe>
+    </div>
+    <iframe id="captions"
+      src="https://www.streamtext.net/player/?event=RoguelikeCelebration&chat=false&header=false&footer=false&indicator=false&ff=Consolas&fgc=93a1a1"
+      frameborder="0"
+      allow="autoplay; encrypted-media;"
+      allowfullscreen
+      style="width: 100%; flex-grow: 1"
+    ></iframe>
+  </div>
 </body>
 <script>
   document.addEventListener('DOMContentLoaded', function() {

--- a/stream.html
+++ b/stream.html
@@ -1,10 +1,11 @@
 <html>
   <head>
     <title>Roguelike Celebration Stream</title>
+    <link rel="stylesheet" href="style/room.css">
   </head>
 </html>
 
-<body style='overflow-x: hidden'>
+<body style='overflow-x: hidden; width: 100%; margin: auto'>
   <div style="height: 100%; display: flex; flex-flow: column;">
     <div style="height: 0; width: 100%; position: relative; padding-bottom: 56.25%">
       <iframe id="embed"
@@ -19,7 +20,7 @@
       frameborder="0"
       allow="autoplay; encrypted-media;"
       allowfullscreen
-      style="width: 100%; flex-grow: 1"
+      style="width: 100%; flex-grow: 1;"
     ></iframe>
   </div>
 </body>

--- a/style/room.css
+++ b/style/room.css
@@ -39,7 +39,3 @@ a.room-link:visited {
   border-color: var(--highlight-line);
   padding-top: 5px;
 }
-
-#static-room-description iframe {
-  max-width: 100%;
-}


### PR DESCRIPTION
This was originally just a "make the theater embed not a 0-width gray bar" but it morphed into also having a resizable stream popout with a css'd caption box. Also the caption box was malformed/not present due to iframes not being able to close themselves (!? who knew!?) in the popup so fixed that.

Tried in chromium, firefox on Ubuntu

![Screenshot from 2020-10-01 15-27-34](https://user-images.githubusercontent.com/1434086/94869881-16418780-03fb-11eb-8623-102b452cd10c.png)
![Screenshot from 2020-10-01 15-27-49](https://user-images.githubusercontent.com/1434086/94869882-16da1e00-03fb-11eb-8014-e29812d28752.png)
![Screenshot from 2020-10-01 15-28-05](https://user-images.githubusercontent.com/1434086/94869883-16da1e00-03fb-11eb-8875-7b05f33c4989.png)
![Screenshot from 2020-10-01 15-28-14](https://user-images.githubusercontent.com/1434086/94869884-1772b480-03fb-11eb-8a71-cc61cd24a8a0.png)
