### PR TITLE
Colors are surprisingly hard

### DIFF
--- a/style/style.css
+++ b/style/style.css
@@ -8,16 +8,16 @@
   --gray-text: #b5b5b5;
   --alternate-background: #333333;
   --alternate-translucent: rgba(51,51,51,0.8);
-  --green: lightseagreen;
-  --highlight-line: #666666;
+  --green: #20b2aa;
+  --highlight-line: #cecece;
   --pink: lightpink;
-  --blue: lightskyblue;
-  --cyan: cyan;
-  --magenta: darkmagenta;
-  --orange: orange;
-  --red: red;
-  --violet: violet;
-  --yellow: yellow;
+  --blue: #2a2aff;
+  --cyan: #008078;
+  --magenta: #8b008b;
+  --orange: #be5600;
+  --red: #ff0000;
+  --violet: #b83eb8;
+  --yellow: #727203;
 }
 
 /* solarized dark */


### PR DESCRIPTION
...I don't think this is good enough, and I'm also baffled by why we're using `--green` for our links instead of the more traditional blue. But, I mean...it's better than it is now?

I went with making the highlight line really different than the background because that's how the other themes are and besides, we use it to outline buttons, where it's important for it to be different. I'm not sure why we use it to outline buttons though!

![Screenshot from 2020-10-02 15-56-43](https://user-images.githubusercontent.com/1434086/94976525-1fe5f080-04ca-11eb-89b7-724cae54200e.png)
![Screenshot from 2020-10-02 15-58-35](https://user-images.githubusercontent.com/1434086/94976526-207e8700-04ca-11eb-8bd6-719711780da9.png)
![Screenshot from 2020-10-02 16-01-03](https://user-images.githubusercontent.com/1434086/94976527-21171d80-04ca-11eb-9456-17b95b1d3d04.png)
![Screenshot from 2020-10-02 16-02-24](https://user-images.githubusercontent.com/1434086/94976528-21171d80-04ca-11eb-8dc8-5d65a23a5c2d.png)
![Screenshot from 2020-10-02 16-03-27](https://user-images.githubusercontent.com/1434086/94976530-21afb400-04ca-11eb-9bc3-d4afb7720fae.png)
![Screenshot from 2020-10-02 16-05-00](https://user-images.githubusercontent.com/1434086/94976531-21afb400-04ca-11eb-9781-b5d8a1b96854.png)
![Screenshot from 2020-10-02 16-06-21](https://user-images.githubusercontent.com/1434086/94976532-21afb400-04ca-11eb-94a6-4b56a401bf87.png)
![Screenshot from 2020-10-02 16-21-09](https://user-images.githubusercontent.com/1434086/94976926-6a1ba180-04cb-11eb-8175-d5597b8ea494.png)

