### PR TITLE
Fix the articles for gross cookies

### DIFF
--- a/server/src/generators/fortuneCookies.ts
+++ b/server/src/generators/fortuneCookies.ts
@@ -144,7 +144,7 @@ export const generate = () => {
     bad: [
       '#ugh#, #gross#!',
       '#ugh#, tastes like #badFlavor#.',
-      'A #gross# cookie #thatsLike# #badFlavor##weirdly#.'
+      '#aGross# cookie #thatsLike# #badFlavor##weirdly#.'
     ],
     ugh: [
       'Ugh',
@@ -152,13 +152,19 @@ export const generate = () => {
       'Blergh',
       'Blah'
     ],
+    aGross: [
+      "A #gross#",
+      "An #awful#"
+    ],
     gross: [
       'gross',
       'bizarre',
-      'awful',
       'nasty',
+      'vile'
+    ],
+    awful: [
+      'awful',
       'icky',
-      'vile',
       'odious'
     ],
     badFlavor: [


### PR DESCRIPTION
the grammar could generate things like "A awful cookie...".
this change splits the "gross" adjectives that starts with a vowel from those that start with a consonant and pairs them with the right article (a/an)

---

* this is the most nitpicky PR
* I am not doing this for a shirt
* I'm really enjoying the conference and the MUD!
* you probably have more important things to worry about 😅 