### PR TITLE
Hotfixes: Shorten description of link note wall, fix link for Lords of Cyberspace

### DIFF
--- a/server/src/rooms/index.ts
+++ b/server/src/rooms/index.ts
@@ -178,7 +178,7 @@ const indexRoomData: { [name: string]: Room } = {
       noteWallButton: 'Add a link',
       addNoteLinkText: 'add a link',
       addNotePrompt: 'What would you like to link to?',
-      noteWallDescription: 'Links to slides, videos, files, and articles the community should look into.'
+      noteWallDescription: 'Links to slides, videos, files, and articles of interest.'
     }
   },
   workbench: {

--- a/server/src/rooms/westShowcaseHall.ts
+++ b/server/src/rooms/westShowcaseHall.ts
@@ -67,7 +67,7 @@ export default {
             the hardware and software you acquire to cause as much trouble in cyberspace as is humanly possible." Christopher
             Swenson ported it to work on the web by adapting and recompiling it under modern Linux and macOS systems. You can see
             an explanation video
-            <a ref="https://www.youtube.com/watch?v=3HzKYwzWFYM" target="_blank" rel="nofollow noopener noreferrer">here</a>
+            <a href="https://www.youtube.com/watch?v=3HzKYwzWFYM" target="_blank" rel="nofollow noopener noreferrer">here</a>
             and play the game at
             <a href="https://lords-of-cyberspace.glitch.me/" target="_blank">https://lords-of-cyberspace.glitch.me/</a>!
           </p>


### PR DESCRIPTION
Shorten description of link note wall, fix link for Lords of Cyberspace