### PR TITLE
Issue 459: Filter transcripts for empty strings

### DIFF
--- a/src/speechRecognizer.ts
+++ b/src/speechRecognizer.ts
@@ -37,7 +37,9 @@ export async function setUpSpeechRecognizer (
   recognizer.recognized = (s, e) => {
     if (e.result.reason === ResultReason.RecognizedSpeech) {
       console.log(`RECOGNIZED: Text=${e.result.text}`)
-      dispatch(SendCaptionAction(e.result.text))
+      if (e.result.text !== '') {
+        dispatch(SendCaptionAction(e.result.text))
+      }
     } else if (e.result.reason === ResultReason.NoMatch) {
       console.log('NOMATCH: Speech could not be recognized.')
     }


### PR DESCRIPTION
I'm not entirely sure if this will 100% fix it because it's plausible that it'll return long strings of whitespace, but it seemed to fix it when I tested it.

It's also kind of hard to test because you have to make weird noises at your computer and hope it comes up with empty strings instead of just not recognizing it at all, so that must've been funny to watch.

closes #459 