### PR TITLE
[WIP] Issue 444: revamped videochat UI

### DIFF
--- a/src/components/LocalMediaView.tsx
+++ b/src/components/LocalMediaView.tsx
@@ -33,7 +33,7 @@ export default function LocalMediaView (props: Props) {
 
   return (
     <div className="my-video">
-      You:
+      You
       {localStreamView}
       {props.hideUI ? '' : (
         <div>

--- a/src/components/MediaChatView.tsx
+++ b/src/components/MediaChatView.tsx
@@ -89,8 +89,8 @@ export default function MediaChatView (props: MediaProps) {
       })
       if (anyAudioTracks || anyVideoTracks) {
         return (
-          <div key={`stream-wrapper-${p.identity}`}>
-            <NameView userId={p.identity} id={`stream-nameview-${p.identity}`} />:
+          <div key={`stream-wrapper-${p.identity}`} className='participant-track-square'>
+            <NameView userId={p.identity} id={`stream-nameview-${p.identity}`} />
             <ParticipantTracks participant={p} />
           </div>
         )
@@ -117,7 +117,7 @@ export default function MediaChatView (props: MediaProps) {
       <label>{otherVideos ? otherVideos.length : 0} other chatters ({numHiddenFeeds} offscreen). </label>
       <button onClick={() => setRowsToDisplay(rowsToDisplay + 1)}>Show More</button>
       <button onClick={() => setRowsToDisplay(Math.max(0, rowsToDisplay - 1))}>Show Less</button>
-      <div id="media-view" ref={ref} style={{maxHeight: rowsToDisplay * ROW_HEIGHT}}>
+      <div id="media-view" ref={ref} style={{height: rowsToDisplay * ROW_HEIGHT, maxHeight: rowsToDisplay * ROW_HEIGHT}}>
           {playerVideo} {otherVideos}
       </div>
     </div>

--- a/src/components/MediaChatView.tsx
+++ b/src/components/MediaChatView.tsx
@@ -9,6 +9,7 @@ import LocalMediaView from './LocalMediaView'
 import '../../style/videoChat.css'
 import { useMediaChatContext } from '../videochat/mediaChatContext'
 import ParticipantTracks from '../videochat/twilio/ParticipantTracks'
+import { JsxElement } from 'typescript'
 
 // TODO: We should allow you to not send media but still consume it
 interface MediaProps {
@@ -19,7 +20,6 @@ interface MediaProps {
 }
 
 export default function MediaChatView (props: MediaProps) {
-  let mediaSelector
   const { publishingCamera, callParticipants } = useMediaChatContext()
   console.log('Re-rendering media chat view?')
 
@@ -30,7 +30,7 @@ export default function MediaChatView (props: MediaProps) {
     )
   }
 
-  let otherVideos
+  let otherVideos: JSX.Element[]
   console.log(callParticipants)
   if (callParticipants) {
     const liveTracks = (Array.from(callParticipants.values())).map((p) => {
@@ -64,7 +64,7 @@ export default function MediaChatView (props: MediaProps) {
 
   return (
     <div id="media-view">
-      {playerVideo} {mediaSelector} {otherVideos}
+      {playerVideo} {otherVideos}
     </div>
   )
 }

--- a/style/videoChat.css
+++ b/style/videoChat.css
@@ -12,8 +12,19 @@ input#send-audio {
 #media-view {
   display: flex;
   flex-flow: row wrap;
-  max-height: 190px;
+  max-height: 195px;
   overflow: hidden;
+  border-style: solid;
+  border-color: white;
+  border-width: 1px;
+}
+
+.participant-track-square {
+  max-height: 195px;
+  min-height: 195px;
+  min-width: 180px;
+  max-width: 180px;
+  overflow: hidden
 }
 
 video.speaking {

--- a/style/videoChat.css
+++ b/style/videoChat.css
@@ -1,7 +1,8 @@
 video {
   display: block;
   box-sizing: border-box;
-  width: 180px;
+  width: 180px; /** I guess this is where we set the width? */
+  height: 135px;
 }
 
 input#send-audio {
@@ -11,6 +12,8 @@ input#send-audio {
 #media-view {
   display: flex;
   flex-flow: row wrap;
+  max-height: 190px;
+  overflow: hidden;
 }
 
 video.speaking {


### PR DESCRIPTION
Open for UI consultation; frontend's not my forte. Also I'm not sure if this will cause big perf costs or not.

Right now what I've done is made the videochat a fixed-size element. It will always take [rows * video height] space up, and you can crank it up/down with the buttons. There's no ordering to the videos other than that your square is always first.

![Screenshot from 2021-10-08 17-21-01](https://user-images.githubusercontent.com/1434086/136637325-9e29aa9c-376b-4f68-9854-2254907697f4.png)
![Screenshot from 2021-10-08 17-20-49](https://user-images.githubusercontent.com/1434086/136637326-3ca1cd18-5067-4879-97b2-c73a3bf3ad63.png)
![Screenshot from 2021-10-08 17-20-34](https://user-images.githubusercontent.com/1434086/136637327-8487117b-34f3-4a6e-868c-758da3a6d8f4.png)
![Screenshot from 2021-10-08 17-19-50](https://user-images.githubusercontent.com/1434086/136637329-227e2e96-8ebe-421c-8500-d42461c55783.png)
![Screenshot from 2021-10-08 17-19-33](https://user-images.githubusercontent.com/1434086/136637330-510c414f-06b7-4af1-8adb-4add98a73380.png)

closes #444 