### PR TITLE
Add minimize media chat toggle

### DIFF
--- a/src/components/MediaChatView.tsx
+++ b/src/components/MediaChatView.tsx
@@ -15,6 +15,8 @@ interface MediaProps {
 export default function MediaChatView (props: MediaProps) {
   const { publishingCamera, callParticipants } = useMediaChatContext()
 
+  // TODO: The show/hide video bar is implemented without changing what's rendered - all it does right now is sets the
+  // size of the container to height=0. Ideally we'd actually not render the video tracks as video.
   const [showVideoBar, setShowVideoBar] = useState(true)
 
   const toggleVideoBar = () => {
@@ -83,7 +85,7 @@ export default function MediaChatView (props: MediaProps) {
         {showVideoBar ? audioParticipants.length : 'all'} offscreen).{' '}
       </label>
       <button id={'button-toggle-video-bar'} onClick={() => toggleVideoBar()} className='link-styled-button'>
-          {showVideoBar ? 'Hide Video Bar' : 'Show Video Bar'}
+        {showVideoBar ? 'Hide Video Bar' : 'Show Video Bar'}
       </button>
       <div id="media-view" style={customStyle}>
         {playerVideo} {videoParticipants} {audioParticipants}

--- a/src/components/MediaChatView.tsx
+++ b/src/components/MediaChatView.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, VideoHTMLAttributes, useRef } from 'react'
+import React, { useEffect, VideoHTMLAttributes, useRef, useState } from 'react'
 import NameView from './NameView'
 import LocalMediaView from './LocalMediaView'
 
@@ -14,6 +14,12 @@ interface MediaProps {
 
 export default function MediaChatView (props: MediaProps) {
   const { publishingCamera, callParticipants } = useMediaChatContext()
+
+  const [showVideoBar, setShowVideoBar] = useState(true)
+
+  const toggleVideoBar = () => {
+    setShowVideoBar(!showVideoBar)
+  }
 
   // TODO: props.visibleSpeakers should never be undefined, but it is?!
   const visibleSpeakers = (props.visibleSpeakers || []).map(x => x[0])
@@ -66,13 +72,20 @@ export default function MediaChatView (props: MediaProps) {
       />
     })
 
+  // If we're showing the bar, we don't override the height; if we're hiding we force it to 0.
+  // We still want it to render the audioParticipants, so that's why we still paint it.
+  // TODO: this is jank
+  const customStyle = { height: showVideoBar ? undefined : '0px' }
   return (
     <div id="media-wrapper">
       <label>
         {participants ? participants.length : 0} other chatters (
-        {audioParticipants.length} offscreen).{' '}
+        {showVideoBar ? audioParticipants.length : 'all'} offscreen).{' '}
       </label>
-      <div id="media-view">
+      <button id={'button-toggle-video-bar'} onClick={() => toggleVideoBar()} className='link-styled-button'>
+          {showVideoBar ? 'Hide Video Bar' : 'Show Video Bar'}
+      </button>
+      <div id="media-view" style={customStyle}>
         {playerVideo} {videoParticipants} {audioParticipants}
       </div>
     </div>


### PR DESCRIPTION
Purely client-side; keeps all existing render logic, just does a dumb `height=0` set on the container if it's in hide mode.

![Screenshot from 2021-10-13 14-49-32](https://user-images.githubusercontent.com/1434086/137217740-fbf3c6ff-bdef-42e6-b689-110da8c71680.png)
![Screenshot from 2021-10-13 14-49-40](https://user-images.githubusercontent.com/1434086/137217739-56d3b81a-6b03-46c1-a821-9f30254c3c30.png)
![Screenshot from 2021-10-13 14-49-57](https://user-images.githubusercontent.com/1434086/137217737-465455b0-6143-4496-ae6b-c94efd97122d.png)