### PR TITLE
Various videochat bugfixes/hacks

### DIFF
--- a/src/components/MediaSelectorView.tsx
+++ b/src/components/MediaSelectorView.tsx
@@ -67,13 +67,6 @@ export default function MediaSelectorView (props: Props) {
 
   const clickJoin = () => {
     dispatch(HideModalAction())
-
-    if (props.hideVideo) {
-      publishAudio()
-    } else {
-      dispatch(StartVideoChatAction())
-      publishMedia()
-    }
   }
 
   let video
@@ -117,9 +110,7 @@ export default function MediaSelectorView (props: Props) {
       <div>
         <VideoAudioSettingsView keepCameraWhenMoving={props.keepCameraWhenMoving} />
       </div>
-      {props.showJoinButton
-        ? <button id="join" onClick={clickJoin}>Join</button>
-        : ''}
+      <button id="join" onClick={clickJoin}>Use These Devices</button>
     </div>
   )
 }

--- a/src/components/RoomView.tsx
+++ b/src/components/RoomView.tsx
@@ -41,8 +41,6 @@ export default function RoomView (props: Props) {
     currentMic,
     currentCamera,
     joinCall,
-    publishMedia,
-    publishAudio,
     unpublishMedia
   } = useMediaChatContext()
   const { room } = props

--- a/src/videochat/twilioChatContext.tsx
+++ b/src/videochat/twilioChatContext.tsx
@@ -116,8 +116,9 @@ export const TwilioChatContextProvider = (props: {
     setPublishingCamera(true)
 
     if (localVideoTrack) {
-      room.localParticipant.publishTrack(localVideoTrack)
       localVideoTrack.restart()
+      localVideoTrack.enable(true)
+      room.localParticipant.publishTrack(localVideoTrack)
 
       if (!localStreamView) {
         setLocalStreamView(<VideoTrack track={localVideoTrack} />)

--- a/src/videochat/twilioChatContext.tsx
+++ b/src/videochat/twilioChatContext.tsx
@@ -156,7 +156,7 @@ export const TwilioChatContextProvider = (props: {
       }
     }
 
-    setLocalStreamView(undefined)
+    // setLocalStreamView(undefined)
   }
 
   useEffect(() => {
@@ -406,7 +406,7 @@ export const TwilioChatContextProvider = (props: {
 
         // TODO: Should this function be moved elsewhere?
         // Should this logic live in a useEffect hook?
-        setCurrentCamera: (id: string) => {
+        setCurrentCamera: async (id: string) => {
           console.log(`[TWILIO] Setting current camera from ${currentCamera.id} (${currentCamera.name}) to ${id}`)
           if (currentCamera && currentCamera.id !== id) {
             console.log('[TWILIO] Removing old camera', room)
@@ -415,23 +415,36 @@ export const TwilioChatContextProvider = (props: {
               // TODO: room.unpublishTrack(localVideoTrack) wasn't working for some reason
               // This blunt approach works for now, but will need changing if we
               // e.g. add in screen sharing
+              /*
               room.localParticipant.videoTracks.forEach(publication => {
                 publication.unpublish()
               })
+              */
+              // TODO: There were huge issues with inconsistency with async timing issues leading to different media
+              // being shown to others versus shown to you - that is, users thought they were using the wrong camera.
+              // Booting the user out whenever they fiddle with their camera is brutal, but fixes it.
+              dispatch(StopVideoChatAction())
+              unpublishMedia()
             }
           }
           setCurrentCameraInternal(cameras.find((c) => c.id === id))
+          localVideoTrack.restart()
+          return null
         },
         setCurrentMic: (id: string) => {
           if (currentMic && currentMic.id !== id) {
             localAudioTrack.stop()
             if (room) {
-              room.localParticipant.audioTracks.forEach(publication => {
+              /* room.localParticipant.audioTracks.forEach(publication => {
                 publication.unpublish()
-              })
+              }) */
+              dispatch(StopVideoChatAction())
+              unpublishMedia()
             }
           }
           setCurrentMicInternal(mics.find(c => c.id === id))
+          localAudioTrack.restart()
+          return null
         },
 
         localStreamView,


### PR DESCRIPTION
Please go commit by commit to review, they're reasonably atomic.

Issues seen last night:
* Sam/Britta/Me formed the Forbidden Triangle (everybody can see/hear one person, but two people can't see one another)
* Joining, leaving, then joining chat black square'd you <- there's a fix in there
* The selector join button hard-failed often (something about audio not unpublished?) <- I just changed it to "Use These Settings" and made it close the modal
* Joining, leaving chat then opening media selector didn't show the feed in the selector <- fix in there
* The media selector would refuse to honor your camera, only sometimes switching your local feed. Worse, your local feed was not synced up with your public feed! <- added a restart() call to the video track, and boot the user out when they fiddle with settings (also removes the issue of immediately showing camera) - **double-check the audio changes too** because I couldn't test those.