### PR TITLE
Tweaking generators to match the action

### DIFF
--- a/server/src/generators/deepFriedSnacks.ts
+++ b/server/src/generators/deepFriedSnacks.ts
@@ -3,7 +3,7 @@
 import tracery from 'tracery-grammar'
 
 export const actionString = (deepFriedSnacks: string) => {
-  return `You devour some ${deepFriedSnacks}!`
+  return `You get some ${deepFriedSnacks}!`
 }
 
 export const generate = () => {

--- a/server/src/generators/popcorn.ts
+++ b/server/src/generators/popcorn.ts
@@ -3,7 +3,7 @@
 import tracery from 'tracery-grammar'
 
 export const actionString = (popcorn: string) => {
-  return `You eat a bag of ${popcorn}!`
+  return `You are given a bag of ${popcorn}!`
 }
 
 export const generate = () => {


### PR DESCRIPTION
Previously generators described you eating things, since I wasn't thinking of the items as permanent. Now that you can walk around with them, the text should match that action.