### PR TITLE
Update currentEventBadge for 2025 event

### DIFF
--- a/server/src/badges.ts
+++ b/server/src/badges.ts
@@ -1,6 +1,9 @@
 import { keyBy } from 'lodash'
 import { BadgeCategories } from './types'
 
+// See server/src/moveToRoom.ts for the badge-awarding logic, including the setting for
+// which is the current-event badge.
+
 export interface Badge {
   /** We don't do any checks around string length, because Unicode Is Weird.
   * ~Please~ don't make this longer than one rendered character */

--- a/server/src/moveToRoom.ts
+++ b/server/src/moveToRoom.ts
@@ -182,7 +182,7 @@ function awardBadges (user: User, roomId: string) {
   // Unlock the "I attended!" badge for the current event
   // This is gated on time, so you can update this for a future event.
   // Just change the emoji, the month, and the year.
-  const currentEventBadge = UnlockableBadgeMap['9️⃣']
+  const currentEventBadge = UnlockableBadgeMap['🔟'] // "10" = Year2025 badge
   const today = new Date()
   if (!includes(user.unlockedBadges, currentEventBadge) &&
     today.getMonth() === 9 && // getMonth is 0-indexed, not 1-indexed


### PR DESCRIPTION
Update the current event badge to "10" for 2025. It was left on last year's badge for 2024, and still was handing those out. Probably didn't catch this during the Preview because the current-event badge handout is time-gated, and didn't get activated until October; the Preview was back in September.

Addresses https://github.com/Roguelike-Celebration/azure-mud/issues/948, specifically https://github.com/Roguelike-Celebration/azure-mud/issues/948#issuecomment-3445095335.