### PR TITLE
Fix Steam Sale link in nav bar for 2025 event

### DIFF
--- a/src/components/SideNavView.tsx
+++ b/src/components/SideNavView.tsx
@@ -47,7 +47,7 @@ export default function SideNavView (props: Props) {
         <MenuItem title="Code of Conduct" modal={Modal.CodeOfConduct} />
         <MenuItem title="Obelisk" modal={Modal.Obelisk} img='🔮' imgAlt='crystal ball'/>
         <a href="https://www.redbubble.com/people/Roguelike/shop" rel="noreferrer" target="_blank" style={{ color: 'var(--main-font)', textDecoration: 'none' }}><li><span role="img" aria-label="shirt">👕</span>Merch</li></a>
-        <a href="https://store.steampowered.com/sale/roguelikecelebration2025" rel="noreferrer" target="_blank" style={{ color: 'var(--main-font)', textDecoration: 'none' }}><li><span role="img" aria-label="shirt"></span>Steam Sale</li></a>
+        <a href="https://store.steampowered.com/curator/41222044/sale/RoguelikeCelebration2025" rel="noreferrer" target="_blank" style={{ color: 'var(--main-font)', textDecoration: 'none' }}><li><span role="img" aria-label="shirt"></span>Steam Sale</li></a>
         <MenuItem title="Help" modal={Modal.Help} />
       </ul>
       {props.presenceData && props.currentRoomId


### PR DESCRIPTION
Link was updated in the gameTables room data, but not here.