### PR TITLE
Add Pop Out Stream and Pop Out Captions links back to theater room description

### DIFF
--- a/server/src/rooms/data/roomData.json
+++ b/server/src/rooms/data/roomData.json
@@ -62,7 +62,7 @@
     "displayName": "The Big Top",
     "shortName": "big top",
     "id": "theater",
-    "description": "You enter the central tent to find a massive stage suffused with the smell of unseen fried snacks. Performers circle the edges, and even more strangely the attention of everyone in the room appears to be focused on people who are just standing in the center. Talking. You decide to sit and listen for a while.<br/><br/>You can return to the [[Pavilion]]. Or if you'd like to speak to one of our speakers after their talk, you can head to breakout rooms: [[Dressing Rooms]], [[Props Closet]], [[Break Room]], [[Under The Stage]]. (Check the 'Happening Now' button on the left for speaker room assignments!)",
+    "description": "You enter the central tent to find a massive stage suffused with the smell of unseen fried snacks. Performers circle the edges, and even more strangely the attention of everyone in the room appears to be focused on people who are just standing in the center. Talking. You decide to sit and listen for a while.<br/><br/>You can return to the [[Pavilion]]. Or if you'd like to speak to one of our speakers after their talk, you can head to breakout rooms: [[Dressing Rooms]], [[Props Closet]], [[Break Room]], [[Under The Stage]]. (Check the 'Happening Now' button on the left for speaker room assignments!) <a href=\"stream.html\" onClick=\"window.open('stream.html#' + window.getComputedStyle(document.body).getPropertyValue('background-color'), 'stream', 'width=560,height=460'); return false\">Pop Out Stream</a>. <a href=\"https://www.streamtext.net/player?event=RoguelikeCelebration \" target=\"_blank\">Pop Out Live Captions</a>.<br/>",
 	  "hidden": false,
 	  "hasNoteWall": true,
     "noteWallData": {


### PR DESCRIPTION
Fixes #971.

This PR gets the Pop Out Stream links etc. in to `roomData.json`, so if we do live editing to fix it in the theater now, it doesn't get lost if we revert to room data from disk.